### PR TITLE
Add setup instructions and an example for workflow engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ ENV/
 # IDE
 .idea/
 .vscode/
+
+# Output
+/workflow_output/

--- a/README.md
+++ b/README.md
@@ -2,51 +2,60 @@
 
 Workflow Engine is a modular workflow orchestration system designed for running and chaining node-based tasks. It currently supports a file-based data model for persisting node outputs and passing data between nodes based on MIME types.
 
+## Getting Started
+
+```sh
+pip install ... # TODO
+```
+
+See the `examples` folder for example workflows.
+
 ## Features
 
-- **Graph-Based Workflow Execution:**  
+- **Graph-Based Workflow Execution:**
   Execute workflows defined as directed graphs. The engine uses topological sorting for dependency resolution.
 
-- **Modular Node Execution:**  
+- **Modular Node Execution:**
   Each node processes inputs, executes a function, and produces outputs. Data is passed between nodes based on MIME types.
 
-- **File-Based Data Persistence:**  
+- **File-Based Data Persistence:**
   Node outputs are wrapped in a `FileExecutionData` object, saved to a document store (using Supabase), and retrieved by matching MIME types.
 
-- **Flexible Resolver Architecture:**  
+- **Flexible Resolver Architecture:**
   The engine decouples workflow logic from storage and function retrieval using a `BaseResolver` interface, with a concrete `SupabaseResolver` implementation.
 
-- **Robust Error Handling and Logging:**  
+- **Robust Error Handling and Logging:**
   Built-in error propagation and logging help to diagnose and resolve issues during workflow execution.
 
-- **Future Enhancements:**  
+- **Future Enhancements:**
   Planned improvements include support for:
   - A more flexible data model (e.g., ephemeral and in-memory data)
   - Iterative workflows and sub-workflows (allowing controlled cycles)
   - Enhanced concurrency, parallel support
 
-
 ### Key Modules
 
-- **`workflow.py`**  
+- **`workflow.py`**
   Contains the `WorkflowExecutor` class, which:
   - Loads and validates workflows as directed acyclic graphs (DAGs)
   - Executes nodes in topological order
   - Handles input gathering, function invocation, and saving of results
 
-- **`types.py`**  
+- **`types.py`**
   Contains the Pydantic and dataclass models for:
   - Defining the workflow structure (`Node`, `Edge`, `WorkflowGraph`)
   - Representing file-based data (`File`, `FileExecutionData`)
   - Utility functions like `calc_file_size`
 
-## Installation
+## Development
 
-...
+```sh
+pip install -r requirements.txt
+pip install -e .
+```
 
 ## TODO
 
 Allow nodes to be run for multiple iterations
 Support parallel workflows
 Finish in_memory implementation
-

--- a/examples/linear.py
+++ b/examples/linear.py
@@ -1,0 +1,46 @@
+import workflow_engine as we
+
+
+async def linear_example():
+    output_dir = "./workflow_output"
+    resolver = we.resolvers.InMemoryResolver(
+        persist_results=True,
+        output_dir=output_dir,
+    )
+    executor = we.WorkflowExecutor(resolver)
+
+    graph = we.WorkflowGraph(
+        nodes=[
+            generate_text_node := we.Node(
+                id="generate_text",
+                name="Generate Text",
+                reference_id=we.functions.builtins.generate_text_file.__name__,
+            ),
+            process_json_node := we.Node(
+                id="process_json",
+                name="Process JSON",
+                reference_id=we.functions.builtins.process_text_to_json.__name__,
+            ),
+        ],
+        edges=[
+            we.Edge(
+                id=f"{generate_text_node.id}-{process_json_node.id}",
+                source=generate_text_node.id,
+                target=process_json_node.id,
+                sourceHandle="text/plain",
+                targetHandle="text/plain",
+                target_parameter="input_files",
+            ),
+        ],
+    )
+    executor.load_workflow(graph.model_dump(by_alias=True))
+
+    await resolver.initialize()
+    run_id, results = await executor.execute()
+    await resolver.persist_run_results(run_id)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(linear_example())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+networkx==3.4.2
+pydantic==2.11.1
+pytest==8.3.5
+pytest-asyncio==0.26.0
+python-dotenv==1.1.0
+supabase==2.15.0

--- a/src/workflow_engine/resolvers/in_memory.py
+++ b/src/workflow_engine/resolvers/in_memory.py
@@ -83,8 +83,10 @@ class InMemoryResolver(BaseResolver):
     async def get_function_config(self, node_data: Node) -> Dict[str, Any]:
         """Retrieves configuration directly from the Node object's config field."""
         logger.debug(f"Retrieving config for node {node_data.id} from node definition.")
-        # Return a copy to prevent modification of the original workflow definition
-        return (node_data.config or {}).copy()
+        if hasattr(node_data, "config"):
+            # Return a copy to prevent modification of the original workflow definition
+            return (node_data.config or {}).copy()  # type: ignore
+        return {}
 
     async def save_node_results(
         self, node_id: str, results: NodeOutputData, run_id: str


### PR DESCRIPTION
This adds `examples/linear.py` with my best understanding of how the workflow is supposed to be called based on `tests`.
Also adds a `requirements.txt` based on the essential packages for development, with versions copied out of `poetry.lock`.