### PR TITLE
Update SupaBase context to rewrite file paths on final return

### DIFF
--- a/src/workflow_engine/contexts/local.py
+++ b/src/workflow_engine/contexts/local.py
@@ -132,11 +132,12 @@ class LocalContext(Context):
             node: Node,
             input: Data,
             output: Data,
-    ):
+    ) -> Data:
         self._idempotent_write(
             path=self.get_node_output_path(node.id),
             data=output.model_dump_json(),
         )
+        return output
 
     def on_workflow_finish(
             self,
@@ -144,11 +145,12 @@ class LocalContext(Context):
             workflow: Workflow,
             input: Mapping[str, Any],
             output: Mapping[str, Any],
-    ):
+    ) -> Mapping[str, Any]:
         self._idempotent_write(
             path=self.workflow_output_path,
             data=json.dumps(output),
         )
+        return output
 
 
 __all__ = [

--- a/src/workflow_engine/core/context.py
+++ b/src/workflow_engine/core/context.py
@@ -69,11 +69,11 @@ class Context(ABC):
             node: "Node",
             input: Data,
             output: Data,
-    ) -> None:
+    ) -> Data:
         """
         A hook that is called when a node finishes execution.
         """
-        pass
+        return output
 
     def on_workflow_finish(
             self,
@@ -81,11 +81,11 @@ class Context(ABC):
             workflow: "Workflow",
             input: Mapping[str, Any],
             output: Mapping[str, Any],
-    ) -> None:
+    ) -> Mapping[str, Any]:
         """
         A hook that is called when a workflow finishes execution.
         """
-        pass
+        return output
 
 
 __all__ = [

--- a/src/workflow_engine/execution/topological.py
+++ b/src/workflow_engine/execution/topological.py
@@ -27,11 +27,11 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
             node_id, node_input = ready_nodes.popitem()
             node = workflow.nodes_by_id[node_id]
 
-            output = context.on_node_start(node=node, input=node_input)
-            if output is None:
-                output = node(context, node_input)
-                context.on_node_finish(node=node, input=node_input, output=output)
-            node_outputs[node.id] = output
+            node_output = context.on_node_start(node=node, input=node_input)
+            if node_output is None:
+                node_output = node(context, node_input)
+                node_output = context.on_node_finish(node=node, input=node_input, output=node_output)
+            node_outputs[node.id] = node_output
             ready_nodes = dict(workflow.get_ready_nodes(
                 input=input,
                 node_outputs=node_outputs,
@@ -39,7 +39,7 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
             ))
 
         output = workflow.get_output(node_outputs)
-        context.on_workflow_finish(
+        output = context.on_workflow_finish(
             workflow=workflow,
             input=input,
             output=output,


### PR DESCRIPTION
The Supabase context virtually puts every file inside a folder for the workflow's ID. At the end, it will unroll those files by prepending the workflow ID to the file paths.