### PR TITLE
Gracefully handle workflow errors and provide partial results

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check the `examples` directory for more sample workflows:
 
 - [`addition.py/json`](./examples/addition.py): basic arithmetic operations
 - [`append.py/json`](./examples/append.py): text file manipulation
+- [`error.py/json`](./examples/error.py): graceful error handling
 
 ## Key Features
 

--- a/examples/append.py
+++ b/examples/append.py
@@ -1,6 +1,12 @@
 # examples/append.py
 from workflow_engine.contexts.supabase import SupabaseContext
-from workflow_engine.core import InputEdge, OutputEdge, TextFile, Workflow
+from workflow_engine import (
+    InputEdge,
+    OutputEdge,
+    Workflow,
+    WorkflowExecutionError,
+)
+from workflow_engine.core import TextFile
 from workflow_engine.execution.topological import TopologicalExecutionAlgorithm
 from workflow_engine.nodes import AppendToFileNode, AppendToFileParams
 
@@ -71,6 +77,7 @@ output = algorithm.execute(
     workflow=workflow,
     input=input,
 )
+assert not isinstance(output, WorkflowExecutionError)
 print(output)
 
 output_file = TextFile.model_validate(output["file"])

--- a/examples/error.json
+++ b/examples/error.json
@@ -1,0 +1,34 @@
+{
+    "nodes": [
+        {
+            "type": "ConstantString",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "params": {
+                "value": "workflow-engine"
+            }
+        },
+        {
+            "type": "Error",
+            "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "params": {
+                "error_name": "RuntimeError"
+            }
+        }
+    ],
+    "edges": [
+        {
+            "source_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "source_key": "value",
+            "target_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "target_key": "info"
+        }
+    ],
+    "input_edges": [],
+    "output_edges": [
+        {
+            "source_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "source_key": "value",
+            "output_key": "text"
+        }
+    ]
+}

--- a/examples/error.py
+++ b/examples/error.py
@@ -1,0 +1,91 @@
+# examples/append.py
+from workflow_engine.contexts.supabase import SupabaseContext
+from workflow_engine import (
+    Edge,
+    NodeExecutionError,
+    OutputEdge,
+    Workflow,
+    WorkflowExecutionError,
+)
+from workflow_engine.execution.topological import TopologicalExecutionAlgorithm
+from workflow_engine.nodes import (
+    ConstantStringNode,
+    ErrorNode,
+)
+
+# ==============================================================================
+# WORKFLOW
+
+workflow = Workflow(
+    nodes=[
+        constant := ConstantStringNode.from_value(
+            node_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            value="workflow-engine",
+        ),
+        error := ErrorNode.from_name(
+            node_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            name="RuntimeError",
+        ),
+    ],
+    edges=[
+        Edge.from_nodes(
+            source=constant,
+            source_key="value",
+            target=error,
+            target_key="info",
+        ),
+    ],
+    input_edges=[],
+    output_edges=[
+        OutputEdge.from_node(
+            source=constant,
+            source_key="value",
+            output_key="text",
+        ),
+    ],
+)
+workflow_json = workflow.model_dump_json(indent=4)
+with open("examples/error.json", "w") as f:
+    f.write(workflow_json)
+
+# make sure serialization roundtrip works
+assert Workflow.model_validate_json(workflow_json) == workflow
+
+
+# ==============================================================================
+# CONTEXT
+
+run_id = "33333333-3333-3333-3333-000000000002"
+
+context = SupabaseContext(
+    run_id=run_id,
+    user_id="9dd979c4-6426-40ca-bcaf-7a7f03d550d4",
+    workflow_version_id="a842f092-0a85-446f-863e-c92ef9c99e67",
+)
+
+
+# ==============================================================================
+# ALGORITHMS
+
+
+algorithm = TopologicalExecutionAlgorithm()
+
+
+# ==============================================================================
+# EXECUTION
+
+output = algorithm.execute(
+    context=context,
+    workflow=workflow,
+    input={},
+)
+print(output)
+assert output == WorkflowExecutionError(
+    node_errors={
+        error.id: NodeExecutionError(
+            node_id=error.id,
+            message="RuntimeError: workflow-engine",
+        )
+    },
+    partial_output={"text": "workflow-engine"},
+)

--- a/src/workflow_engine/__init__.py
+++ b/src/workflow_engine/__init__.py
@@ -9,9 +9,11 @@ from .core import (
     File,
     InputEdge,
     Node,
+    NodeExecutionError,
     OutputEdge,
     Params,
     Workflow,
+    WorkflowExecutionError,
 )
 
 __all__ = [
@@ -23,7 +25,9 @@ __all__ = [
     "File",
     "InputEdge",
     "Node",
+    "NodeExecutionError",
     "OutputEdge",
     "Params",
     "Workflow",
+    "WorkflowExecutionError",
 ]

--- a/src/workflow_engine/core/__init__.py
+++ b/src/workflow_engine/core/__init__.py
@@ -2,6 +2,7 @@
 from .context import Context
 from .data import Data
 from .edge import Edge, InputEdge, OutputEdge
+from .error import NodeExecutionError, WorkflowExecutionError
 from .execution import ExecutionAlgorithm
 from .file import File, JSONFile, JSONLinesFile, TextFile
 from .node import Empty, Node, Params
@@ -18,8 +19,10 @@ __all__ = [
     "JSONFile",
     "JSONLinesFile",
     "Node",
+    "NodeExecutionError",
     "OutputEdge",
     "Params",
     "TextFile",
     "Workflow",
+    "WorkflowExecutionError",
 ]

--- a/src/workflow_engine/core/context.py
+++ b/src/workflow_engine/core/context.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from .data import Data
+from .error import NodeExecutionError, WorkflowExecutionError
 from .file import File
 
 if TYPE_CHECKING:
@@ -41,20 +42,6 @@ class Context(ABC):
     ) -> F:
         raise NotImplementedError("Subclasses must implement this method")
 
-    def on_workflow_start(
-        self,
-        *,
-        workflow: "Workflow",
-        input: Mapping[str, Any],
-    ) -> Mapping[str, Any] | None:
-        """
-        A hook that is called when a workflow starts execution.
-
-        If the context already knows what the workflow's output will be, return
-        that output to skip workflow execution.
-        """
-        pass
-
     def on_node_start(
         self,
         *,
@@ -67,7 +54,21 @@ class Context(ABC):
         If the context already knows what the node's output will be, return that
         output to skip node execution.
         """
-        pass
+        return None
+
+    def on_node_error(
+        self,
+        *,
+        node: "Node",
+        input: Data,
+        error: NodeExecutionError,
+    ) -> NodeExecutionError:
+        """
+        A hook that is called when a node raises an error.
+        The context can modify the error message by returning a different
+        NodeExecutionError.
+        """
+        return error
 
     def on_node_finish(
         self,
@@ -80,6 +81,34 @@ class Context(ABC):
         A hook that is called when a node finishes execution.
         """
         return output
+
+    def on_workflow_start(
+        self,
+        *,
+        workflow: "Workflow",
+        input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        """
+        A hook that is called when a workflow starts execution.
+
+        If the context already knows what the workflow's output will be, return
+        that output to skip workflow execution.
+        """
+        return None
+
+    def on_workflow_error(
+        self,
+        *,
+        workflow: "Workflow",
+        input: Mapping[str, Any],
+        error: WorkflowExecutionError,
+    ) -> WorkflowExecutionError:
+        """
+        A hook that is called when a workflow raises an error.
+        The context can modify the error message by returning a different
+        WorkflowExecutionError.
+        """
+        return error
 
     def on_workflow_finish(
         self,

--- a/src/workflow_engine/core/edge.py
+++ b/src/workflow_engine/core/edge.py
@@ -65,6 +65,18 @@ class Edge(BaseModel):
             )
 
 
+class SynchronizationEdge(BaseModel):
+    """
+    An edge that carries no information, but indicates that the target node must
+    run after the source node finishes.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source_id: str
+    target_id: str
+
+
 class InputEdge(BaseModel):
     """
     An "edge" that maps a field from the workflow's input to the input of a
@@ -161,4 +173,5 @@ __all__ = [
     "Edge",
     "InputEdge",
     "OutputEdge",
+    "SynchronizationEdge",
 ]

--- a/src/workflow_engine/core/error.py
+++ b/src/workflow_engine/core/error.py
@@ -1,0 +1,47 @@
+# workflow_engine/core/error.py
+
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NodeExecutionError(BaseModel):
+    """
+    Any error message representing a problem that prevents the node from
+    producing results.
+    Note that this is not an exception class, and should not actually be raised.
+    Instead, nodes should "raise" this exception by returning this object.
+
+    Exceptions raised by nodes will not be handled gracefully.
+
+    ```
+    try:
+        ...
+    except SomeException as e:
+        return NodeExecutionError(...)
+    ```
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    node_id: str
+    message: str
+
+
+class WorkflowExecutionError(BaseModel):
+    """
+    Any error message representing a problem that prevents the workflow from
+    producing full results.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    node_errors: Mapping[str, NodeExecutionError]
+    partial_output: Mapping[str, Any]
+
+
+__all__ = [
+    "NodeExecutionError",
+    "WorkflowExecutionError",
+]

--- a/src/workflow_engine/core/execution.py
+++ b/src/workflow_engine/core/execution.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from .context import Context
+from .error import WorkflowExecutionError
 from .workflow import Workflow
 
 
@@ -21,7 +22,7 @@ class ExecutionAlgorithm(ABC):
         context: Context,
         workflow: Workflow,
         input: Mapping[str, Any],
-    ) -> Mapping[str, Any]:
+    ) -> Mapping[str, Any] | WorkflowExecutionError:
         pass
 
 

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, model_validator
 
 from .context import Context
 from .data import Data, Input_contra, Output_co
+from .error import NodeExecutionError
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +126,11 @@ class Node(BaseModel, Generic[Input_contra, Output_co, Params_co]):
         return self
 
     # @abstractmethod
-    def __call__(self, context: Context, input: Input_contra) -> Output_co:
+    def __call__(
+        self,
+        context: Context,
+        input: Input_contra,
+    ) -> Output_co | NodeExecutionError:
         raise NotImplementedError("Subclasses must implement this method")
 
 

--- a/src/workflow_engine/core/workflow.py
+++ b/src/workflow_engine/core/workflow.py
@@ -154,9 +154,12 @@ class Workflow(BaseModel):
     def get_output(
         self,
         node_outputs: Mapping[str, Data],
+        partial: bool = False,
     ) -> Mapping[str, Any]:
         output: dict[str, Any] = {}
         for edge in self.output_edges:
+            if partial and edge.source_id not in node_outputs:
+                continue
             output_field = getattr(node_outputs[edge.source_id], edge.source_key)
             if isinstance(output_field, BaseModel):
                 output_field = output_field.model_dump()

--- a/src/workflow_engine/nodes/__init__.py
+++ b/src/workflow_engine/nodes/__init__.py
@@ -12,6 +12,10 @@ from .constant import (
     ConstantString,
     ConstantStringNode,
 )
+from .error import (
+    ErrorNode,
+    ErrorParams,
+)
 from .json import (
     ReadJSONLinesNode,
     ReadJSONNode,
@@ -36,6 +40,8 @@ __all__ = [
     "ConstantIntNode",
     "ConstantString",
     "ConstantStringNode",
+    "ErrorNode",
+    "ErrorParams",
     "FactorizationNode",
     "ReadJSONLinesNode",
     "ReadJSONNode",

--- a/src/workflow_engine/nodes/error.py
+++ b/src/workflow_engine/nodes/error.py
@@ -1,0 +1,48 @@
+# workflow_engine/nodes/error.py
+
+from typing import Literal
+
+from ..core import (
+    Context,
+    Data,
+    Empty,
+    Node,
+    NodeExecutionError,
+    Params,
+)
+
+
+class ErrorInput(Data):
+    info: str
+
+
+class ErrorParams(Params):
+    error_name: str
+
+
+class ErrorNode(Node[ErrorInput, Empty, ErrorParams]):
+    """
+    A node that always raises an error.
+    """
+
+    type: Literal["Error"] = "Error"
+
+    @property
+    def input_type(self):
+        return ErrorInput
+
+    def __call__(self, context: Context, input: ErrorInput) -> NodeExecutionError:
+        return NodeExecutionError(
+            node_id=self.id,
+            message=f"{self.params.error_name}: {input.info}",
+        )
+
+    @classmethod
+    def from_name(cls, node_id: str, name: str) -> "ErrorNode":
+        return cls(id=node_id, params=ErrorParams(error_name=name))
+
+
+__all__ = [
+    "ErrorNode",
+    "ErrorParams",
+]


### PR DESCRIPTION
This PR is in response to some pretty bad debugging experience when implementing concrete workflows for customers.

Add JSON `error` columns to the Supabase `workflow_runs` and `workflow_node_runs` database tables. Nodes and workflows themselves now return an `output | error` value which trigger different context hooks. Raised exceptions will still cause a workflow to crash ungracefully.

The idea is that workflow users are not trusted, so they should not see arbitrary exception information -- but node implementations can choose to surface safe error messages to display.