### PR TITLE
Switch to exceptions for error handling

### DIFF
--- a/examples/addition.py
+++ b/examples/addition.py
@@ -59,9 +59,10 @@ algorithm = TopologicalExecutionAlgorithm()
 # ==============================================================================
 # EXECUTION
 
-output = algorithm.execute(
+errors, output = algorithm.execute(
     context=context,
     workflow=workflow,
     input={"c": -256},
 )
+assert not errors
 assert output == {"sum": 42 + 2025 - 256}

--- a/examples/append.py
+++ b/examples/append.py
@@ -4,7 +4,6 @@ from workflow_engine import (
     InputEdge,
     OutputEdge,
     Workflow,
-    WorkflowExecutionError,
 )
 from workflow_engine.core import TextFile
 from workflow_engine.execution.topological import TopologicalExecutionAlgorithm
@@ -72,12 +71,12 @@ input = {
 input_file = TextFile.model_validate(input["file"])
 input_text = input_file.read_text(context)
 
-output = algorithm.execute(
+errors, output = algorithm.execute(
     context=context,
     workflow=workflow,
     input=input,
 )
-assert not isinstance(output, WorkflowExecutionError)
+assert not errors
 print(output)
 
 output_file = TextFile.model_validate(output["file"])

--- a/examples/error.py
+++ b/examples/error.py
@@ -2,10 +2,9 @@
 from workflow_engine.contexts.supabase import SupabaseContext
 from workflow_engine import (
     Edge,
-    NodeExecutionError,
     OutputEdge,
     Workflow,
-    WorkflowExecutionError,
+    WorkflowErrors,
 )
 from workflow_engine.execution.topological import TopologicalExecutionAlgorithm
 from workflow_engine.nodes import (
@@ -55,7 +54,7 @@ assert Workflow.model_validate_json(workflow_json) == workflow
 # ==============================================================================
 # CONTEXT
 
-run_id = "33333333-3333-3333-3333-000000000002"
+run_id = "33333333-3333-3333-3333-000000000006"
 
 context = SupabaseContext(
     run_id=run_id,
@@ -74,18 +73,15 @@ algorithm = TopologicalExecutionAlgorithm()
 # ==============================================================================
 # EXECUTION
 
-output = algorithm.execute(
+errors, output = algorithm.execute(
     context=context,
     workflow=workflow,
     input={},
 )
-print(output)
-assert output == WorkflowExecutionError(
-    node_errors={
-        error.id: NodeExecutionError(
-            node_id=error.id,
-            message="RuntimeError: workflow-engine",
-        )
-    },
-    partial_output={"text": "workflow-engine"},
+print("Errors:", errors)
+print("Output:", output)
+assert errors == WorkflowErrors(
+    workflow_errors=[],
+    node_errors={error.id: ["RuntimeError: workflow-engine"]},
 )
+assert output == {"text": "workflow-engine"}

--- a/src/workflow_engine/__init__.py
+++ b/src/workflow_engine/__init__.py
@@ -9,11 +9,12 @@ from .core import (
     File,
     InputEdge,
     Node,
-    NodeExecutionError,
+    NodeException,
     OutputEdge,
     Params,
+    UserException,
     Workflow,
-    WorkflowExecutionError,
+    WorkflowErrors,
 )
 
 __all__ = [
@@ -25,9 +26,10 @@ __all__ = [
     "File",
     "InputEdge",
     "Node",
-    "NodeExecutionError",
+    "NodeException",
     "OutputEdge",
     "Params",
+    "UserException",
     "Workflow",
-    "WorkflowExecutionError",
+    "WorkflowErrors",
 ]

--- a/src/workflow_engine/contexts/local.py
+++ b/src/workflow_engine/contexts/local.py
@@ -7,7 +7,9 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
-from ..core import Context, Data, File, Node, Workflow
+from workflow_engine.core.error import WorkflowErrors
+
+from ..core import Context, File, Node, Workflow
 
 F = TypeVar("F", bound=File)
 
@@ -56,11 +58,18 @@ class LocalContext(Context):
         return os.path.join(self.run_dir, "input.json")
 
     @property
+    def workflow_error_path(self) -> str:
+        return os.path.join(self.run_dir, "error.json")
+
+    @property
     def workflow_output_path(self) -> str:
         return os.path.join(self.run_dir, "output.json")
 
     def get_node_input_path(self, node_id: str) -> str:
         return os.path.join(self.input_dir, f"{node_id}.json")
+
+    def node_error_path(self, node_id: str) -> str:
+        return os.path.join(self.run_dir, f"{node_id}.error.json")
 
     def get_node_output_path(self, node_id: str) -> str:
         return os.path.join(self.output_dir, f"{node_id}.json")
@@ -88,30 +97,43 @@ class LocalContext(Context):
         self,
         *,
         node: Node,
-        input: Data,
-    ) -> Data | None:
+        input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
         self._idempotent_write(
             path=self.get_node_input_path(node.id),
-            data=input.model_dump_json(),
+            data=json.dumps(input),
         )
 
         output_path = self.get_node_output_path(node.id)
         if os.path.exists(output_path):
             with open(output_path, "r") as f:
-                output = node.output_type.model_validate_json(f.read())  # type: ignore
+                output = json.load(f)
             return output
         return None
+
+    def on_node_error(
+        self,
+        *,
+        node: Node,
+        input: Mapping[str, Any],
+        exception: Exception,
+    ) -> Exception | Mapping[str, Any]:
+        self._idempotent_write(
+            path=self.node_error_path(node.id),
+            data=json.dumps(exception),
+        )
+        return exception
 
     def on_node_finish(
         self,
         *,
         node: Node,
-        input: Data,
-        output: Data,
-    ) -> Data:
+        input: Mapping[str, Any],
+        output: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
         self._idempotent_write(
             path=self.get_node_output_path(node.id),
-            data=output.model_dump_json(),
+            data=json.dumps(output),
         )
         return output
 
@@ -120,7 +142,7 @@ class LocalContext(Context):
         *,
         workflow: Workflow,
         input: Mapping[str, Any],
-    ) -> Mapping[str, Any] | None:
+    ) -> tuple[WorkflowErrors, Mapping[str, Any]] | None:
         """
         Triggered when a workflow is started.
         If the context already knows what the node's output will be, it can
@@ -146,8 +168,38 @@ class LocalContext(Context):
             with open(output_path, "r") as f:
                 output = json.load(f)
             assert isinstance(output, dict)
-            return output
+            return WorkflowErrors(), output
+
+        error_path = self.workflow_error_path
+        if os.path.exists(error_path):
+            with open(error_path, "r") as f:
+                error_and_output = json.load(f)
+            assert isinstance(error_and_output, dict)
+            errors = WorkflowErrors.model_validate(error_and_output["errors"])
+            output = error_and_output["output"]
+            assert isinstance(output, dict)
+            return errors, output
+
         return None
+
+    def on_workflow_error(
+        self,
+        *,
+        workflow: Workflow,
+        input: Mapping[str, Any],
+        errors: WorkflowErrors,
+        partial_output: Mapping[str, Any],
+    ) -> tuple[WorkflowErrors, Mapping[str, Any]]:
+        self._idempotent_write(
+            path=self.workflow_error_path,
+            data=json.dumps(
+                {
+                    "errors": errors.model_dump(),
+                    "output": partial_output,
+                }
+            ),
+        )
+        return errors, partial_output
 
     def on_workflow_finish(
         self,

--- a/src/workflow_engine/contexts/supabase.py
+++ b/src/workflow_engine/contexts/supabase.py
@@ -4,15 +4,7 @@ from typing import Any, TypeVar
 
 from supabase import create_client
 
-from ..core import (
-    Context,
-    Data,
-    File,
-    Node,
-    NodeExecutionError,
-    Workflow,
-    WorkflowExecutionError,
-)
+from ..core import Context, File, Node, UserException, Workflow, WorkflowErrors
 from ..utils.env import get_env
 from ..utils.iter import only
 from ..utils.uuid import is_valid_uuid
@@ -122,8 +114,11 @@ class SupabaseContext(Context):
     ) -> bytes:
         file_id = self.get_file_id(file)
         if file_id is None:
-            raise ValueError(f"File {file.path} not found")
-        content = self.file_bucket.download(f"{self.user_id}/{file_id}")
+            raise UserException(f"File {file.path} not found")
+        try:
+            content = self.file_bucket.download(f"{self.user_id}/{file_id}")
+        except Exception as e:
+            raise UserException(f"Failed to read file {file.path}") from e
         return content
 
     def write(
@@ -155,8 +150,8 @@ class SupabaseContext(Context):
         self,
         *,
         node: Node,
-        input: Data,
-    ) -> Data | None:
+        input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
         """
         A hook that is called when a node starts execution.
 
@@ -178,7 +173,7 @@ class SupabaseContext(Context):
             {
                 "workflow_run_id": self.run_id,
                 "node_id": node.id,
-                "input": input.model_dump(),
+                "input": input,
                 "started_at": "now()",
                 "output": None,
                 "finished_at": None,
@@ -190,16 +185,21 @@ class SupabaseContext(Context):
         self,
         *,
         node: "Node",
-        input: Data,
-        error: NodeExecutionError,
-    ) -> NodeExecutionError:
+        input: Mapping[str, Any],
+        exception: Exception,
+    ) -> Exception | Mapping[str, Any]:
         """
         A hook that is called when a node finishes execution.
         """
+        persisted_exception = (
+            {"message": exception.message}
+            if isinstance(exception, UserException)
+            else {}
+        )
         (
             self.workflow_node_runs_table.update(
                 {
-                    "error": error.model_dump(),
+                    "error": persisted_exception,
                     "finished_at": "now()",
                 }
             )
@@ -207,22 +207,22 @@ class SupabaseContext(Context):
             .eq("node_id", node.id)
             .execute()
         )
-        return error
+        return exception
 
     def on_node_finish(
         self,
         *,
         node: "Node",
-        input: Data,
-        output: Data,
-    ) -> Data:
+        input: Mapping[str, Any],
+        output: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
         """
         A hook that is called when a node finishes execution.
         """
         (
             self.workflow_node_runs_table.update(
                 {
-                    "output": output.model_dump(),
+                    "output": output,
                     "finished_at": "now()",
                 }
             )
@@ -237,18 +237,28 @@ class SupabaseContext(Context):
         *,
         workflow: Workflow,
         input: Mapping[str, Any],
-    ) -> Mapping[str, Any] | None:
+    ) -> tuple[WorkflowErrors, Mapping[str, Any]] | None:
         """
         A hook that is called when a workflow starts execution.
 
         If the context already knows what the workflow's output will be, return
         that output to skip workflow execution.
         """
-        response = self.workflow_runs_table.select("*").eq("id", self.run_id).execute()
+        response = (
+            self.workflow_runs_table.select("error", "output")
+            .eq("id", self.run_id)
+            .not_.is_("output", None)
+            .execute()
+        )
         if len(response.data) > 0:
+            error = only(response.data)["error"]
             output = only(response.data)["output"]
-            if output is not None:
-                return output
+            assert isinstance(output, dict)
+            if error is None:
+                errors = WorkflowErrors()
+            else:
+                errors = WorkflowErrors.model_validate(error)
+            return errors, output
 
         self.workflow_runs_table.upsert(
             {
@@ -267,21 +277,21 @@ class SupabaseContext(Context):
         *,
         workflow: "Workflow",
         input: Mapping[str, Any],
-        error: WorkflowExecutionError,
-    ) -> WorkflowExecutionError:
-        error_json = error.model_dump()
+        errors: WorkflowErrors,
+        partial_output: Mapping[str, Any],
+    ) -> tuple[WorkflowErrors, Mapping[str, Any]]:
         (
             self.workflow_runs_table.update(
                 {
-                    "error": error_json["node_errors"],
-                    "output": error_json["partial_output"],
+                    "error": errors.model_dump(),
+                    "output": partial_output,
                     "finished_at": "now()",
                 }
             )
             .eq("id", self.run_id)
             .execute()
         )
-        return error
+        return errors, partial_output
 
     def on_workflow_finish(
         self,

--- a/src/workflow_engine/core/__init__.py
+++ b/src/workflow_engine/core/__init__.py
@@ -2,7 +2,7 @@
 from .context import Context
 from .data import Data
 from .edge import Edge, InputEdge, OutputEdge
-from .error import NodeExecutionError, WorkflowExecutionError
+from .error import NodeException, UserException, WorkflowErrors
 from .execution import ExecutionAlgorithm
 from .file import File, JSONFile, JSONLinesFile, TextFile
 from .node import Empty, Node, Params
@@ -19,10 +19,11 @@ __all__ = [
     "JSONFile",
     "JSONLinesFile",
     "Node",
-    "NodeExecutionError",
+    "NodeException",
     "OutputEdge",
     "Params",
     "TextFile",
+    "UserException",
     "Workflow",
-    "WorkflowExecutionError",
+    "WorkflowErrors",
 ]

--- a/src/workflow_engine/core/execution.py
+++ b/src/workflow_engine/core/execution.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from .context import Context
-from .error import WorkflowExecutionError
+from .error import WorkflowErrors
 from .workflow import Workflow
 
 
@@ -22,7 +22,7 @@ class ExecutionAlgorithm(ABC):
         context: Context,
         workflow: Workflow,
         input: Mapping[str, Any],
-    ) -> Mapping[str, Any] | WorkflowExecutionError:
+    ) -> tuple[WorkflowErrors, Mapping[str, Any]]:
         pass
 
 

--- a/src/workflow_engine/nodes/arithmetic.py
+++ b/src/workflow_engine/nodes/arithmetic.py
@@ -29,7 +29,7 @@ class AddNode(Node[AddNodeInput, SumOutput, Empty]):
     def output_type(self):
         return SumOutput
 
-    def __call__(self, context: Context, input: AddNodeInput) -> SumOutput:
+    def run(self, context: Context, input: AddNodeInput) -> SumOutput:
         return SumOutput(sum=input.a + input.b)
 
 
@@ -52,7 +52,7 @@ class SumNode(Node[SumNodeInput, SumNodeOutput, Empty]):
     def output_type(self):
         return SumNodeOutput
 
-    def __call__(self, context: Context, input: SumNodeInput) -> SumNodeOutput:
+    def run(self, context: Context, input: SumNodeInput) -> SumNodeOutput:
         return SumNodeOutput(sum=sum(input.values))
 
 
@@ -75,7 +75,7 @@ class FactorizationNode(Node[IntData, FactorizationData, Params]):
     def output_type(self):
         return FactorizationData
 
-    def __call__(self, context: Context, input: IntData) -> FactorizationData:
+    def run(self, context: Context, input: IntData) -> FactorizationData:
         if input.value > 0:
             return FactorizationData(
                 factors=[i for i in range(1, input.value + 1) if input.value % i == 0]

--- a/src/workflow_engine/nodes/constant.py
+++ b/src/workflow_engine/nodes/constant.py
@@ -15,7 +15,7 @@ class ConstantBoolNode(Node[Empty, ConstantBool, ConstantBool]):
     def output_type(self):
         return ConstantBool
 
-    def __call__(self, context: Context, input: Empty) -> ConstantBool:
+    def run(self, context: Context, input: Empty) -> ConstantBool:
         return self.params
 
     @classmethod
@@ -34,7 +34,7 @@ class ConstantIntNode(Node[Empty, ConstantInt, ConstantInt]):
     def output_type(self):
         return ConstantInt
 
-    def __call__(self, context: Context, input: Empty) -> ConstantInt:
+    def run(self, context: Context, input: Empty) -> ConstantInt:
         return self.params
 
     @classmethod
@@ -53,7 +53,7 @@ class ConstantStringNode(Node[Empty, ConstantString, ConstantString]):
     def output_type(self) -> Type[ConstantString]:
         return ConstantString
 
-    def __call__(self, context: Context, input: Data) -> ConstantString:
+    def run(self, context: Context, input: Data) -> ConstantString:
         return ConstantString(value=self.params.value)
 
     @classmethod

--- a/src/workflow_engine/nodes/error.py
+++ b/src/workflow_engine/nodes/error.py
@@ -7,8 +7,8 @@ from ..core import (
     Data,
     Empty,
     Node,
-    NodeExecutionError,
     Params,
+    UserException,
 )
 
 
@@ -31,11 +31,8 @@ class ErrorNode(Node[ErrorInput, Empty, ErrorParams]):
     def input_type(self):
         return ErrorInput
 
-    def __call__(self, context: Context, input: ErrorInput) -> NodeExecutionError:
-        return NodeExecutionError(
-            node_id=self.id,
-            message=f"{self.params.error_name}: {input.info}",
-        )
+    def run(self, context: Context, input: ErrorInput) -> Empty:
+        raise UserException(f"{self.params.error_name}: {input.info}")
 
     @classmethod
     def from_name(cls, node_id: str, name: str) -> "ErrorNode":

--- a/src/workflow_engine/nodes/json.py
+++ b/src/workflow_engine/nodes/json.py
@@ -36,7 +36,7 @@ class ReadJSONNode(Node[JSONFileData, JSONData, Empty]):
     def output_type(self):
         return JSONData
 
-    def __call__(self, context: Context, input: JSONFileData) -> JSONData:
+    def run(self, context: Context, input: JSONFileData) -> JSONData:
         return JSONData(data=input.file.read_data(context))
 
 
@@ -60,7 +60,7 @@ class WriteJSONNode(Node[JSONData, JSONFileData, WriteJSONParams]):
     def output_type(self):
         return JSONFileData
 
-    def __call__(self, context: Context, input: JSONData) -> JSONFileData:
+    def run(self, context: Context, input: JSONData) -> JSONFileData:
         file = JSONFile(path=self.params.file_name)
         file = file.write_data(context, input.data)
         return JSONFileData(file=file)
@@ -89,7 +89,7 @@ class ReadJSONLinesNode(Node[JSONLinesFileData, JSONLinesData, Empty]):
     def output_type(self):
         return JSONLinesData
 
-    def __call__(self, context: Context, input: JSONLinesFileData) -> JSONLinesData:
+    def run(self, context: Context, input: JSONLinesFileData) -> JSONLinesData:
         return JSONLinesData(data=input.file.read_data(context))
 
 
@@ -113,7 +113,7 @@ class WriteJSONLinesNode(Node[JSONLinesData, JSONLinesFileData, WriteJSONLinesPa
     def output_type(self):
         return JSONLinesFileData
 
-    def __call__(self, context: Context, input: JSONLinesData) -> JSONLinesFileData:
+    def run(self, context: Context, input: JSONLinesData) -> JSONLinesFileData:
         file = JSONLinesFile(path=self.params.file_name)
         file = file.write_data(context, input.data)
         return JSONLinesFileData(file=file)

--- a/src/workflow_engine/nodes/text.py
+++ b/src/workflow_engine/nodes/text.py
@@ -35,9 +35,7 @@ class AppendToFileNode(Node[AppendToFileInput, AppendToFileOutput, AppendToFileP
     def output_type(self):
         return AppendToFileOutput
 
-    def __call__(
-        self, context: Context, input: AppendToFileInput
-    ) -> AppendToFileOutput:
+    def run(self, context: Context, input: AppendToFileInput) -> AppendToFileOutput:
         old_text = input.file.read_text(context)
         new_text = old_text + input.text
         filename, ext = os.path.splitext(input.file.path)


### PR DESCRIPTION
After trying to use error handling on Aceteam, I've realized the shortcomings of surfacing errors as return values. Specifically, if you're deep inside a bunch of helper functions, you really don't want to repeatedly forward the error object out of the node.

This PR fixes that by providing a specific exception type `UserException` that allows for arbitrary messages to be sent out from failing nodes. Otherwise, the error information is wiped from the response, but the user still learns that there was _some_ error.

Just like #11, this breaks users of the package.