### PR TITLE
Add castable types

### DIFF
--- a/src/workflow_engine/contexts/supabase.py
+++ b/src/workflow_engine/contexts/supabase.py
@@ -93,9 +93,6 @@ class SupabaseContext(Context):
         return self.supabase.table(self.workflow_node_runs_table_name)
 
     def get_env(self, key: str, default: str | None = None) -> str:
-        """
-        Maybe in the long run we will have a
-        """
         return get_env(key, default=default)
 
     def get_file_id(self, file: File) -> str | None:

--- a/src/workflow_engine/core/data.py
+++ b/src/workflow_engine/core/data.py
@@ -8,15 +8,13 @@ class Data(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
 
-Input = TypeVar("Input", bound=Data)
 Input_contra = TypeVar("Input_contra", bound=Data, contravariant=True)
 
-Output = TypeVar("Output", bound=Data)
 Output_co = TypeVar("Output_co", bound=Data, covariant=True)
 
 
 __all__ = [
     "Data",
-    "Input",
-    "Output",
+    "Input_contra",
+    "Output_co",
 ]

--- a/src/workflow_engine/core/value.py
+++ b/src/workflow_engine/core/value.py
@@ -1,0 +1,246 @@
+from collections.abc import Mapping, Sequence
+from logging import getLogger
+from typing import (
+    Callable,
+    ClassVar,
+    Generic,
+    TYPE_CHECKING,
+    Self,
+    Type,
+    TypeVar,
+    TypeAliasType,
+    cast,
+    get_args,
+    get_origin,
+)
+
+from pydantic import ConfigDict, PrivateAttr, RootModel
+
+if TYPE_CHECKING:
+    from .context import Context
+
+
+logger = getLogger(__name__)
+
+
+T = TypeVar("T")
+V = TypeVar("V", bound="Value")
+
+
+OriginAndArgs = TypeAliasType("OriginAndArgs", tuple[str, tuple[Type["Value"], ...]])
+OriginAndArgsRecursive = TypeAliasType(
+    "OriginAndArgsRecursive", tuple[str, tuple["OriginAndArgsRecursive", ...]]
+)
+Caster = TypeAliasType("Caster", Callable[["Context", "Value"], "Value"])
+GenericCaster = TypeAliasType(
+    "GenericCaster",
+    Callable[[Sequence[Type["Value"]], Sequence[Type["Value"]]], Caster],
+)
+
+
+def get_origin_and_args(t: Type) -> tuple[str, tuple[Type, ...]]:
+    # Pydantic RootModels don't play nice with get_origin and get_args, so we
+    # get the root type directly from the model fields.
+    if issubclass(t, RootModel):
+        info = t.__pydantic_generic_metadata__
+        origin = info["origin"]
+        args = info["args"]
+    else:
+        origin = get_origin(t)
+        args = get_args(t)
+
+    if origin is None:
+        assert len(args) == 0
+        return t.__name__, ()
+    else:
+        assert len(args) > 0
+        return origin.__name__, args
+
+
+def get_origin_and_args_recursive(t: Type["Value"]) -> OriginAndArgsRecursive:
+    origin, args = get_origin_and_args(t)
+    return origin, tuple(get_origin_and_args_recursive(arg) for arg in args)
+
+
+class Value(RootModel[T], Generic[T]):
+    """
+    Wraps an arbitrary read-only value which can be passed as input to a node.
+    Allows users to register arbitrary functions to cast values to other types.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    # these properties force us to implement __eq__ and __hash__ to ignore them
+    _casters: ClassVar[dict[str, GenericCaster]] = {}
+    _resolved_casters: ClassVar[dict[str, GenericCaster] | None] = None
+    _cast_cache: dict[OriginAndArgsRecursive, "Value"] = PrivateAttr(
+        default_factory=dict,
+    )
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        # reinitialize for each subclass so it doesn't just reference the parent
+        cls._casters = {}
+        cls._resolved_casters = None
+
+    @classmethod
+    def _get_casters(cls) -> dict[str, GenericCaster]:
+        """
+        Get all converters for this class, including those inherited from parent classes.
+        This method dynamically builds the converter dictionary by merging converters
+        from the current class and all its parent classes.
+        """
+        if cls._resolved_casters is not None:
+            return cls._resolved_casters
+
+        resolved_casters: dict[str, GenericCaster] = cls._casters.copy()
+
+        # Add converters from all classes in MRO order
+        # (starting from this class, then parents, then parents of parents, ...)
+        for parent in cls.__bases__:
+            if issubclass(parent, Value):
+                parent_casters = parent._get_casters()
+            else:
+                continue
+
+            for origin, caster in parent_casters.items():
+                # converters in the child class override those in the parent
+                # class
+                if origin not in resolved_casters:
+                    resolved_casters[origin] = caster
+
+        cls._resolved_casters = resolved_casters
+        return resolved_casters
+
+    @classmethod
+    def add_cast(cls, t: Type[V], caster: GenericCaster):
+        """
+        Register a possible type cast from this class to the class T.
+        """
+        if cls._resolved_casters is not None:
+            raise RuntimeError(
+                f"Cannot add casters for {cls.__name__} after it has been used to cast values"
+            )
+
+        origin, _ = get_origin_and_args(t)
+
+        assert origin not in cls._casters, (
+            f"Type caster from {cls.__name__} to {origin} already registered"
+        )
+        cls._casters[origin] = caster
+
+    @classmethod
+    def get_caster(cls, t: Type[V]) -> Caster | None:
+        _, from_args = get_origin_and_args(cls)
+        to_name, to_args = get_origin_and_args(t)
+
+        converters = cls._get_casters()
+        if to_name in converters:
+            cast_fn = converters[to_name]
+            # Check if this is a generic cast function (takes 2 arguments) or simple cast function
+            if hasattr(cast_fn, "__code__") and cast_fn.__code__.co_argcount == 2:
+                # Generic cast function
+                cast_fn = cast(GenericCaster, cast_fn)
+                try:
+                    return cast_fn(from_args, to_args)
+                except Exception:
+                    logger.exception(f"Cannot instantiate cast function for type {t}")
+                    return None
+            else:
+                # Simple cast function
+                return cast(Caster, cast_fn)
+
+        if issubclass(cls, t):
+            return lambda ctx, v: v
+
+        return None
+
+    @classmethod
+    def can_cast_to(cls, t: Type[V]) -> bool:
+        return cls.get_caster(t) is not None
+
+    def __eq__(self, other):
+        if not isinstance(other, Value):
+            return False
+        return self.root == other.root
+
+    def __hash__(self):
+        return hash(self.root)
+
+    def cast_to(self, t: Type[V], *, context: "Context") -> V:
+        key = get_origin_and_args_recursive(t)
+        if key in self._cast_cache:
+            casted = self._cast_cache[key]
+            assert isinstance(casted, t)
+            return casted
+
+        cast_fn = self.get_caster(t)
+        if cast_fn is not None:
+            casted = cast_fn(context, self)
+            assert isinstance(casted, t)
+            self._cast_cache[key] = casted
+            return casted
+
+        raise ValueError(f"Cannot convert {self} to {t}")
+
+    @classmethod
+    def cast_from(cls, v: "Value", *, context: "Context") -> Self:
+        return v.cast_to(cls, context=context)
+
+
+class StringValue(Value[str]):
+    pass
+
+
+class IntegerValue(Value[int]):
+    pass
+
+
+class FloatValue(Value[float]):
+    pass
+
+
+V = TypeVar("V", bound=Value)
+
+
+class SequenceValue(Value[Sequence[V]], Generic[V]):
+    root: Sequence[V]
+
+
+class StringMapValue(Value[Mapping[str, V]], Generic[V]):
+    root: Mapping[str, V]
+
+
+Value.add_cast(StringValue, lambda S, T: lambda ctx, v: StringValue(root=str(v.root)))
+IntegerValue.add_cast(
+    FloatValue, lambda S, T: lambda ctx, v: FloatValue(root=float(v.root))
+)
+StringValue.add_cast(
+    IntegerValue, lambda S, T: lambda ctx, v: IntegerValue.model_validate_json(v.root)
+)
+StringValue.add_cast(
+    FloatValue, lambda S, T: lambda ctx, v: FloatValue.model_validate_json(v.root)
+)
+
+
+def cast_sequence(Ss: Sequence[Type[Value]], Ts: Sequence[Type[V]]) -> Caster:
+    (S,) = Ss
+    (T,) = Ts
+    assert S.can_cast_to(T), f"Cannot cast item type {S} to {T}"
+    return lambda ctx, value: SequenceValue[T](
+        root=[x.cast_to(T, context=ctx) for x in value.root]
+    )
+
+
+def cast_map(Ss: Sequence[Type[Value]], Ts: Sequence[Type[V]]) -> Caster:
+    (S,) = Ss
+    (T,) = Ts
+    assert S.can_cast_to(T), f"Cannot cast item type {S} to {T}"
+    return lambda ctx, value: StringMapValue[T](
+        root={k: v.cast_to(T, context=ctx) for k, v in value.root.items()}  # type: ignore
+    )
+
+
+SequenceValue.add_cast(SequenceValue, cast_sequence)
+StringMapValue.add_cast(StringMapValue, cast_map)

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -1,0 +1,395 @@
+from typing import Literal
+
+import pytest
+
+from workflow_engine.core.value import (
+    Value,
+    StringValue,
+    IntegerValue,
+    FloatValue,
+    SequenceValue,
+    StringMapValue,
+    get_origin_and_args,
+    get_origin_and_args_recursive,
+)
+from workflow_engine.contexts.in_memory import InMemoryContext
+
+
+@pytest.fixture
+def context():
+    """Create a test context for value casting operations."""
+    return InMemoryContext()
+
+
+@pytest.mark.unit
+def test_basic_value_creation():
+    """Test basic Value creation and properties."""
+    # Test StringValue
+    str_val = StringValue(root="hello")
+    assert str_val.root == "hello"
+    assert isinstance(str_val, StringValue)
+    assert isinstance(str_val, Value)
+
+    # Test IntegerValue
+    int_val = IntegerValue(root=42)
+    assert int_val.root == 42
+    assert isinstance(int_val, IntegerValue)
+    assert isinstance(int_val, Value)
+
+    # Test FloatValue
+    float_val = FloatValue(root=3.14)
+    assert float_val.root == 3.14
+    assert isinstance(float_val, FloatValue)
+    assert isinstance(float_val, Value)
+
+
+@pytest.mark.unit
+def test_value_equality_and_hash():
+    """Test Value equality and hash functionality."""
+    val1 = StringValue(root="test")
+    val2 = StringValue(root="test")
+    val3 = StringValue(root="different")
+
+    assert val1 == val2
+    assert val1 != val3
+    assert hash(val1) == hash(val2)
+    assert hash(val1) != hash(val3)
+
+    # Test with different types
+    int_val = IntegerValue(root=42)
+    assert val1 != int_val
+    assert hash(val1) != hash(int_val)
+
+
+@pytest.mark.unit
+def test_value_serialization():
+    """Test Value serialization and deserialization."""
+    # Test StringValue
+    str_val = StringValue(root="hello world")
+    json_str = str_val.model_dump_json()
+    deserialized = StringValue.model_validate_json(json_str)
+    assert deserialized == str_val
+
+    # Test IntegerValue
+    int_val = IntegerValue(root=123)
+    json_str = int_val.model_dump_json()
+    deserialized = IntegerValue.model_validate_json(json_str)
+    assert deserialized == int_val
+
+    # Test FloatValue
+    float_val = FloatValue(root=3.14159)
+    json_str = float_val.model_dump_json()
+    deserialized = FloatValue.model_validate_json(json_str)
+    assert deserialized == float_val
+
+
+@pytest.mark.unit
+def test_basic_casting(context):
+    """Test basic casting between Value types."""
+    # Integer to String
+    int_val = IntegerValue(root=42)
+    str_val = int_val.cast_to(StringValue, context=context)
+    assert isinstance(str_val, StringValue)
+    assert str_val.root == "42"
+
+    # String to Integer
+    str_val = StringValue(root="123")
+    int_val = str_val.cast_to(IntegerValue, context=context)
+    assert isinstance(int_val, IntegerValue)
+    assert int_val.root == 123
+
+    # String to Float
+    str_val = StringValue(root="3.14")
+    float_val = str_val.cast_to(FloatValue, context=context)
+    assert isinstance(float_val, FloatValue)
+    assert float_val.root == 3.14
+
+    # Integer to Float
+    int_val = IntegerValue(root=42)
+    float_val = int_val.cast_to(FloatValue, context=context)
+    assert isinstance(float_val, FloatValue)
+    assert float_val.root == 42.0
+
+
+@pytest.mark.unit
+def test_sequence_value(context):
+    """Test SequenceValue functionality."""
+    # Create sequence of integers
+    int_sequence = SequenceValue[IntegerValue](
+        root=[IntegerValue(root=1), IntegerValue(root=2), IntegerValue(root=3)]
+    )
+    assert len(int_sequence.root) == 3
+    assert all(isinstance(x, IntegerValue) for x in int_sequence.root)
+
+    # Cast to sequence of strings
+    str_sequence = int_sequence.cast_to(SequenceValue[StringValue], context=context)
+    assert isinstance(str_sequence, SequenceValue)
+    assert len(str_sequence.root) == 3
+    assert all(isinstance(x, StringValue) for x in str_sequence.root)
+    assert [x.root for x in str_sequence.root] == ["1", "2", "3"]
+
+    # Cast back to sequence of integers
+    int_sequence_again = str_sequence.cast_to(
+        SequenceValue[IntegerValue], context=context
+    )
+    assert int_sequence_again == int_sequence
+
+
+@pytest.mark.unit
+def test_string_map_value(context):
+    """Test StringMapValue functionality."""
+    # Create map of integers
+    int_map = StringMapValue[IntegerValue](
+        root={
+            "a": IntegerValue(root=1),
+            "b": IntegerValue(root=2),
+            "c": IntegerValue(root=3),
+        }
+    )
+    assert len(int_map.root) == 3
+    assert all(isinstance(v, IntegerValue) for v in int_map.root.values())
+
+    # Cast to map of strings
+    str_map = int_map.cast_to(StringMapValue[StringValue], context=context)
+    assert isinstance(str_map, StringMapValue)
+    assert len(str_map.root) == 3
+    assert all(isinstance(v, StringValue) for v in str_map.root.values())
+    assert {k: v.root for k, v in str_map.root.items()} == {
+        "a": "1",
+        "b": "2",
+        "c": "3",
+    }
+
+    # Cast back to map of integers
+    int_map_again = str_map.cast_to(StringMapValue[IntegerValue], context=context)
+    assert int_map_again == int_map
+
+
+@pytest.mark.unit
+def test_cast_from_class_method(context):
+    """Test the cast_from class method."""
+    # Test StringValue.cast_from
+    int_val = IntegerValue(root=42)
+    str_val = StringValue.cast_from(int_val, context=context)
+    assert isinstance(str_val, StringValue)
+    assert str_val.root == "42"
+
+    # Test IntegerValue.cast_from
+    str_val = StringValue(root="123")
+    int_val = IntegerValue.cast_from(str_val, context=context)
+    assert isinstance(int_val, IntegerValue)
+    assert int_val.root == 123
+
+    # Test FloatValue.cast_from
+    int_val = IntegerValue(root=42)
+    float_val = FloatValue.cast_from(int_val, context=context)
+    assert isinstance(float_val, FloatValue)
+    assert float_val.root == 42.0
+
+
+@pytest.mark.unit
+def test_cast_cache(context):
+    """Test that casting results are cached."""
+    int_val = IntegerValue(root=42)
+
+    # First cast should compute the result
+    str_val1 = int_val.cast_to(StringValue, context=context)
+    assert str_val1.root == "42"
+
+    # Second cast should use cache
+    str_val2 = int_val.cast_to(StringValue, context=context)
+    assert str_val2 is str_val1  # Should be the same object from cache
+
+
+@pytest.mark.unit
+def test_invalid_casting(context):
+    """Test that invalid casting raises appropriate errors."""
+    int_val = IntegerValue(root=42)
+
+    # Test casting to a type that doesn't have a registered caster
+    class CustomValue(Value[str]):
+        pass
+
+    # This should fail because there's no registered caster from IntegerValue to CustomValue
+    with pytest.raises(ValueError, match="Cannot convert"):
+        int_val.cast_to(CustomValue, context=context)
+
+
+@pytest.mark.unit
+def test_self_casting(context):
+    """Test that casting to the same type returns the same object."""
+    int_val = IntegerValue(root=42)
+    same_val = int_val.cast_to(IntegerValue, context=context)
+    assert same_val is int_val
+
+
+@pytest.mark.unit
+def test_get_origin_and_args():
+    """Test the get_origin_and_args utility function."""
+    # Test with simple types
+    origin, args = get_origin_and_args(int)
+    assert origin == "int"
+    assert args == ()
+
+    origin, args = get_origin_and_args(str)
+    assert origin == "str"
+    assert args == ()
+
+    # Test with generic types
+    origin, args = get_origin_and_args(list[int])
+    assert origin == "list"
+    assert args == (int,)
+
+    origin, args = get_origin_and_args(dict[str, int])
+    assert origin == "dict"
+    assert args == (str, int)
+
+    # Test with Value types
+    origin, args = get_origin_and_args(Value)
+    assert origin == "Value"
+    assert args == ()
+
+    origin, args = get_origin_and_args(SequenceValue[IntegerValue])
+    assert origin == "SequenceValue"
+    assert args == (IntegerValue,)
+
+
+@pytest.mark.unit
+def test_get_origin_and_args_recursive():
+    """Test the get_origin_and_args_recursive utility function."""
+    # Test with simple types - IntegerValue is a RootModel[int], so it gets the int type
+    result = get_origin_and_args_recursive(IntegerValue)
+    assert result == ("IntegerValue", ())
+
+    # Test with generic types
+    result = get_origin_and_args_recursive(SequenceValue[IntegerValue])
+    assert result == ("SequenceValue", (("IntegerValue", ()),))
+
+
+@pytest.mark.unit
+def test_value_frozen_behavior():
+    """Test that Value objects are frozen (immutable)."""
+    int_val = IntegerValue(root=42)
+
+    # Should not be able to modify the root attribute
+    with pytest.raises(Exception):  # Pydantic will raise an error
+        int_val.root = 100
+
+
+@pytest.mark.unit
+def test_complex_nested_casting(context):
+    """Test complex nested casting scenarios."""
+    # Create a complex nested structure
+    nested_sequence = SequenceValue[SequenceValue[IntegerValue]](
+        root=[
+            SequenceValue[IntegerValue](
+                root=[IntegerValue(root=1), IntegerValue(root=2)]
+            ),
+            SequenceValue[IntegerValue](
+                root=[IntegerValue(root=3), IntegerValue(root=4)]
+            ),
+        ]
+    )
+
+    # Cast to nested sequence of strings
+    str_nested = nested_sequence.cast_to(
+        SequenceValue[SequenceValue[StringValue]], context=context
+    )
+    assert str_nested == SequenceValue[SequenceValue[StringValue]](
+        root=[
+            SequenceValue[StringValue](
+                root=[StringValue(root="1"), StringValue(root="2")]
+            ),
+            SequenceValue[StringValue](
+                root=[StringValue(root="3"), StringValue(root="4")]
+            ),
+        ]
+    )
+
+
+@pytest.mark.unit
+def test_cast_registration(context):
+    """Test that cast functions can be registered and work correctly."""
+
+    class QuestionValue(Value[str]):
+        pass
+
+    class AnswerValue(Value[Literal[42]]):
+        pass
+
+    QuestionValue.add_cast(
+        AnswerValue,
+        lambda S, T: lambda ctx, v: AnswerValue(root=42),
+    )
+
+    # Try to register the same cast again (before any casting operations)
+    with pytest.raises(
+        AssertionError,
+        match="Type caster from QuestionValue to AnswerValue already registered",
+    ):
+        QuestionValue.add_cast(
+            AnswerValue, lambda S, T: lambda ctx, v: AnswerValue(root=42)
+        )
+
+    # Now test that casting works
+    assert QuestionValue.can_cast_to(AnswerValue)
+    question = QuestionValue(root="the universe")
+    answer = question.cast_to(AnswerValue, context=context)
+    assert answer.root == 42
+
+    # Try to register the same cast again (after casting operations)
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot add casters for QuestionValue after it has been used to cast values",
+    ):
+        QuestionValue.add_cast(
+            AnswerValue, lambda S, T: lambda ctx, v: AnswerValue(root=42)
+        )
+
+
+@pytest.mark.unit
+def test_json_parsing_edge_cases():
+    """Test JSON parsing edge cases."""
+    # Test with invalid JSON
+    with pytest.raises(Exception):  # Pydantic will raise a validation error
+        IntegerValue.model_validate_json("invalid json")
+
+    # Test with empty string
+    with pytest.raises(Exception):
+        StringValue.model_validate_json("")
+
+    # Test with null
+    with pytest.raises(Exception):
+        IntegerValue.model_validate_json("null")
+
+
+@pytest.mark.unit
+def test_sequence_value_json():
+    """Test SequenceValue JSON serialization and deserialization."""
+    # Test with simple sequence
+    sequence_json = "[1, 2, 3]"
+    sequence_val = SequenceValue[IntegerValue].model_validate_json(sequence_json)
+    assert len(sequence_val.root) == 3
+    assert [x.root for x in sequence_val.root] == [1, 2, 3]
+
+    # Test serialization back to JSON
+    json_str = sequence_val.model_dump_json()
+    assert json_str == "[1,2,3]"
+
+
+@pytest.mark.unit
+def test_string_map_value_json():
+    """Test StringMapValue JSON serialization and deserialization."""
+    # Test with simple map
+    map_json = '{"a": 1, "b": 2, "c": 3}'
+    map_val = StringMapValue[IntegerValue].model_validate_json(map_json)
+    assert len(map_val.root) == 3
+    assert {k: v.root for k, v in map_val.root.items()} == {"a": 1, "b": 2, "c": 3}
+
+    # Test serialization back to JSON
+    json_str = map_val.model_dump_json()
+    assert json_str == '{"a":1,"b":2,"c":3}'
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -319,7 +319,7 @@ def test_cast_registration(context):
 
     QuestionValue.add_cast(
         AnswerValue,
-        lambda S, T: lambda ctx, v: AnswerValue(root=42),
+        lambda S, T: lambda v, ctx: AnswerValue(root=42),
     )
 
     # Try to register the same cast again (before any casting operations)
@@ -328,7 +328,7 @@ def test_cast_registration(context):
         match="Type caster from QuestionValue to AnswerValue already registered",
     ):
         QuestionValue.add_cast(
-            AnswerValue, lambda S, T: lambda ctx, v: AnswerValue(root=42)
+            AnswerValue, lambda S, T: lambda v, ctx: AnswerValue(root=42)
         )
 
     # Now test that casting works
@@ -343,7 +343,7 @@ def test_cast_registration(context):
         match="Cannot add casters for QuestionValue after it has been used to cast values",
     ):
         QuestionValue.add_cast(
-            AnswerValue, lambda S, T: lambda ctx, v: AnswerValue(root=42)
+            AnswerValue, lambda S, T: lambda v, ctx: AnswerValue(root=42)
         )
 
 


### PR DESCRIPTION
Adds an interface to cast data from one type to another via Pydantic, but doesn't use it for anything just yet.
Nevertheless this is fully tested with the power of Cursor.

## Why??

In C++, you can take any variable `x` and pass it into any function parameter so long as there is an implemented type conversion from the type of `x` to the type expected by the parameter.
This is super powerful and can even happen recursively in generic types like C++ vectors.

We want to enable this with our nodes, but Python isn't exactly C++ so we can't just do a compile time conversion.
Instead, we'll need a unified way to send things from one type to another.
Thus, we introduce the `Value` class, hacked together from Pydantic's `RootModel`.

Each node will take, as input, a string-`Value` object, and it will also output a string-`Value` object.
When we pass a value from the output of one node to the input of another node, we will attempt to typecast it over.
This will remove the need to precisely control a node's output format, since the user will just connect whatever they want as long as an obvious typecast exists.

## What abilities does type casting give me?

```py
five_str = StringValue(root="5")
five_int = five_str.cast_to(IntegerType, context=context)  # IntegerType(root=5)
# or
# five_int = IntegerType.cast_from(five_str, context=context)
```

That looks cute but kind of silly since you can also just call `int("5")` to get `5`.

Here's an ability that some might consider unnatural: we can use a _context_ to provide extremely powerful type casts.
Coming in a later PR, we might have something like:

```py
files = ArrayValue[PDFFileValue].model_validate_json("""
  [
    {"path": "somewhere/in/our/supabase/bucket"},
    {"path": "somewhere/else/in/our/supabase/bucket"}
  ]
""")
text = file.cast_to(ArrayValue[StringValue], context=our_supabase_context)  # reads every PDF using docling
```

## What does it need in return?

We enable casting via the `add_cast` method.

```py
SourceValue.add_cast(TargetValue, lambda S, T: lambda v, ctx: TargetValue(root=...))
```

`S` and `T` are advanced arguments that only really apply for generic types, where the type casting function depends on the element type of a generic type.
For the most part, you can ignore them, but if you must (e.g. if you're reviewing this PR), check out the `ArrayValue` or `StringMapValue` types.