### PR TITLE
Implement IfNode and IfElseNode as composite nodes

### DIFF
--- a/src/workflow_engine/core/context.py
+++ b/src/workflow_engine/core/context.py
@@ -95,8 +95,10 @@ class Context(ABC, EnforceOverrides):
         output: DataMapping,
     ) -> DataMapping:
         """
-        A hook that is called when a node finishes execution.
+        A hook that is called when a node finishes execution by returning a
+        DataMapping (not a Workflow).
 
+        node: the node that finished execution
         input: the input data to the node
         output: the output data from the node
 

--- a/src/workflow_engine/core/data.py
+++ b/src/workflow_engine/core/data.py
@@ -63,10 +63,14 @@ def get_data_fields(cls: type[Data]) -> Mapping[str, tuple[ValueType, bool]]:
     return fields
 
 
+D = TypeVar("D", bound=Data)
+
+
 def build_data_type(
     name: str,
     fields: Mapping[str, tuple[ValueType, bool]],
-) -> type[Data]:
+    base_cls: type[D] = Data,
+) -> type[D]:
     """
     Create a Data subclass whose fields are given by a mapping of field names to
     (ValueType, is_required) tuples.
@@ -89,7 +93,7 @@ def build_data_type(
     }
 
     # Create the class dynamically
-    cls = create_model(name, __base__=Data, **annotations)  # type: ignore
+    cls = create_model(name, __base__=base_cls, **annotations)  # type: ignore
 
     return cls
 

--- a/src/workflow_engine/core/error.py
+++ b/src/workflow_engine/core/error.py
@@ -1,8 +1,12 @@
 # workflow_engine/core/error.py
 
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from .workflow import Workflow
 
 
 class UserException(RuntimeError):
@@ -41,6 +45,27 @@ class NodeException(RuntimeError):
         if isinstance(self.__cause__, UserException):
             return self.__cause__.message
         return None
+
+
+class NodeExpansionException(UserException):
+    """
+    An error that occurred while expanding a node into a workflow.
+    """
+
+    def __init__(self, node_id: str, workflow: "Workflow"):
+        super().__init__(f"Error expanding node {node_id} into the workflow {workflow}")
+        self.node_id = node_id
+        self.workflow = workflow
+
+    @property
+    def message(self) -> str | None:
+        base_message = (
+            f"Error expanding node {self.node_id} into the workflow {self.workflow}"
+        )
+        if isinstance(self.__cause__, UserException):
+            return f"{base_message}, due to {self.__cause__}."
+        else:
+            return base_message
 
 
 class WorkflowErrors(BaseModel):
@@ -88,5 +113,6 @@ class WorkflowErrors(BaseModel):
 __all__ = [
     "UserException",
     "NodeException",
+    "NodeExpansionException",
     "WorkflowErrors",
 ]

--- a/src/workflow_engine/core/value.py
+++ b/src/workflow_engine/core/value.py
@@ -345,7 +345,10 @@ def cast_sequence_to_sequence(
     if not source_item_type.can_cast_to(target_item_type):
         return None
 
-    async def _cast(value: source_type, context: "Context") -> target_type:
+    async def _cast(
+        value: source_type,  # pyright: ignore[reportInvalidTypeForm]
+        context: "Context",
+    ) -> target_type:  # pyright: ignore[reportInvalidTypeForm]
         # Cast all items in parallel
         cast_tasks = [
             x.cast_to(target_item_type, context=context)  # type: ignore
@@ -370,7 +373,10 @@ def cast_string_map_to_string_map(
     if not source_value_type.can_cast_to(target_value_type):
         return None
 
-    async def _cast(value: source_type, context: "Context") -> target_type:
+    async def _cast(
+        value: source_type,  # pyright: ignore[reportInvalidTypeForm]
+        context: "Context",
+    ) -> target_type:  # pyright: ignore[reportInvalidTypeForm]
         # Cast all values in parallel
         items = list(value.root.items())
         keys = [k for k, v in items]

--- a/src/workflow_engine/execution/topological.py
+++ b/src/workflow_engine/execution/topological.py
@@ -35,7 +35,13 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
                 node_id, node_input = ready_nodes.popitem()
                 node = workflow.nodes_by_id[node_id]
 
-                node_outputs[node.id] = await node(context, node_input)
+                node_result = await node(context, node_input)
+                if isinstance(node_result, Workflow):
+                    workflow = workflow.expand_node(node_id, node_result)
+
+                else:
+                    node_outputs[node.id] = node_result
+
                 ready_nodes = dict(
                     workflow.get_ready_nodes(
                         input=input,

--- a/src/workflow_engine/nodes/__init__.py
+++ b/src/workflow_engine/nodes/__init__.py
@@ -4,29 +4,41 @@ from .arithmetic import (
     FactorizationNode,
     SumNode,
 )
+from .conditional import (
+    ConditionalInput,
+    IfElseNode,
+    IfNode,
+)
 from .constant import (
     ConstantBooleanNode,
     ConstantIntegerNode,
     ConstantStringNode,
 )
+from .data import (
+    BuildMappingNode,
+    ExtractKeyNode,
+)
 from .error import (
     ErrorNode,
     ErrorParams,
 )
-
 from .text import (
     AppendToFileNode,
     AppendToFileParams,
 )
 
-
 __all__ = [
     "AddNode",
     "AppendToFileNode",
     "AppendToFileParams",
+    "BuildMappingNode",
+    "ExtractKeyNode",
     "ConstantBooleanNode",
     "ConstantIntegerNode",
     "ConstantStringNode",
+    "ConditionalInput",
+    "IfNode",
+    "IfElseNode",
     "ErrorNode",
     "ErrorParams",
     "FactorizationNode",

--- a/src/workflow_engine/nodes/conditional.py
+++ b/src/workflow_engine/nodes/conditional.py
@@ -3,7 +3,7 @@
 Simple nodes for testing the workflow engine, with limited usefulness otherwise.
 """
 
-from typing import Literal, Self
+from typing import Literal, Self, Type
 
 from overrides import override
 from pydantic import ConfigDict
@@ -52,16 +52,16 @@ class IfNode(Node[ConditionalInput, Empty, IfParams]):
 
     @property
     @override
-    def input_type(self):
+    def input_type(self) -> Type[ConditionalInput]:
         fields = dict(get_data_fields(ConditionalInput))
         for key, value in self.params.if_true.input_fields.items():
             assert key not in fields
             fields[key] = (value, True)
-        return build_data_type("IfInput", fields)
+        return build_data_type("IfInput", fields, base_cls=ConditionalInput)
 
     @property
     @override
-    def output_type(self):
+    def output_type(self) -> Type[Empty]:
         return Empty
 
     @override
@@ -94,16 +94,16 @@ class IfElseNode(Node[ConditionalInput, Data, IfElseParams]):
 
     @property
     @override
-    def input_type(self):
+    def input_type(self) -> Type[ConditionalInput]:
         fields = dict(get_data_fields(ConditionalInput))
         for key, value in self.params.if_true.input_fields.items():
             assert key not in fields
             fields[key] = (value, True)
-        return build_data_type("IfElseInput", fields)
+        return build_data_type("IfElseInput", fields, base_cls=ConditionalInput)
 
     @property
     @override
-    def output_type(self):
+    def output_type(self) -> Type[Data]:
         fields = mapping_intersection(
             self.params.if_true.output_fields,
             self.params.if_false.output_fields,

--- a/src/workflow_engine/nodes/conditional.py
+++ b/src/workflow_engine/nodes/conditional.py
@@ -1,0 +1,140 @@
+# workflow_engine/nodes/conditional.py
+"""
+Simple nodes for testing the workflow engine, with limited usefulness otherwise.
+"""
+
+from typing import Literal, Self
+
+from overrides import override
+from pydantic import ConfigDict
+
+from workflow_engine.core.data import build_data_type, get_data_fields
+
+from ..core import (
+    BooleanValue,
+    Context,
+    Data,
+    Workflow,
+    Empty,
+    Node,
+    Params,
+)
+from ..utils.mappings import mapping_intersection
+
+
+class IfParams(Params):
+    if_true: Workflow
+
+
+class IfElseParams(Params):
+    if_true: Workflow
+    if_false: Workflow
+
+
+class ConditionalInput(Data):
+    model_config = ConfigDict(extra="allow")
+
+    condition: BooleanValue
+
+
+class IfNode(Node[ConditionalInput, Empty, IfParams]):
+    """
+    A node that optionally executes the internal workflow if the boolean
+    condition is true.
+
+    The output of this node is always empty, since there would be no valid
+    output if the condition is false.
+    """
+
+    # TODO: allow conditional nodes with optional output
+
+    type: Literal["If"] = "If"
+
+    @property
+    @override
+    def input_type(self):
+        fields = dict(get_data_fields(ConditionalInput))
+        for key, value in self.params.if_true.input_fields.items():
+            assert key not in fields
+            fields[key] = (value, True)
+        return build_data_type("IfInput", fields)
+
+    @property
+    @override
+    def output_type(self):
+        return Empty
+
+    @override
+    async def run(self, context: Context, input: ConditionalInput) -> Empty | Workflow:
+        if input.condition:
+            return self.params.if_true
+        return Empty()
+
+    @classmethod
+    def from_workflow(
+        cls,
+        node_id: str,
+        if_true: Workflow,
+    ) -> Self:
+        return cls(id=node_id, params=IfParams(if_true=if_true))
+
+
+class IfElseNode(Node[ConditionalInput, Data, IfElseParams]):
+    """
+    A node that executes one of the two internal workflows based on the boolean
+    condition.
+
+    The output of this node is the intersection of the if_true and if_false
+    workflows.
+    """
+
+    # TODO: allow union types
+
+    type: Literal["IfElse"] = "IfElse"
+
+    @property
+    @override
+    def input_type(self):
+        fields = dict(get_data_fields(ConditionalInput))
+        for key, value in self.params.if_true.input_fields.items():
+            assert key not in fields
+            fields[key] = (value, True)
+        return build_data_type("IfElseInput", fields)
+
+    @property
+    @override
+    def output_type(self):
+        fields = mapping_intersection(
+            self.params.if_true.output_fields,
+            self.params.if_false.output_fields,
+        )
+        return build_data_type(
+            "IfElseOutput",
+            {key: (value, True) for key, value in fields.items()},
+        )
+
+    @override
+    async def run(self, context: Context, input: ConditionalInput) -> Workflow:
+        return self.params.if_true if input.condition else self.params.if_false
+
+    @classmethod
+    def from_workflows(
+        cls,
+        node_id: str,
+        if_true: Workflow,
+        if_false: Workflow,
+    ) -> Self:
+        return cls(
+            id=node_id,
+            params=IfElseParams(
+                if_true=if_true,
+                if_false=if_false,
+            ),
+        )
+
+
+__all__ = [
+    "ConditionalInput",
+    "IfNode",
+    "IfElseNode",
+]

--- a/src/workflow_engine/nodes/data.py
+++ b/src/workflow_engine/nodes/data.py
@@ -27,6 +27,15 @@ class BuildMappingOutput(Data):
 
 
 class BuildMappingNode(Node[Data, BuildMappingOutput, BuildMappingParams]):
+    """
+    Creates a new mapping object from the inputs to this node.
+
+    Example:
+        >>> node = BuildMappingNode.from_keys("node_id", ["a", "b", "c"])
+        >>> node.run(context, input={"a": 1, "b": 2, "c": 3}).model_dump()
+        {"mapping": {"a": 1, "b": 2, "c": 3}}
+    """
+
     type: Literal["BuildMapping"] = "BuildMapping"
 
     @property
@@ -77,6 +86,15 @@ class ExtractKeyOutput(Data):
 
 
 class ExtractKeyNode(Node[ExtractKeyInput, ExtractKeyOutput, ExtractKeyParams]):
+    """
+    Extracts a value from a mapping object at a specific key.
+
+    Example:
+        >>> node = ExtractKeyNode.from_key("node_id", "a")
+        >>> node.run(context, input={"mapping": {"a": 1, "b": 2, "c": 3}}).model_dump()
+        {"value": 1}
+    """
+
     type: Literal["ExtractKey"] = "ExtractKey"
 
     @property

--- a/src/workflow_engine/nodes/data.py
+++ b/src/workflow_engine/nodes/data.py
@@ -1,0 +1,107 @@
+# workflow_engine/nodes/constant.py
+from collections.abc import Sequence
+from typing import Literal, Self, Type
+
+from overrides import override
+
+from workflow_engine.core.data import build_data_type
+from workflow_engine.core.value import StringMapValue
+
+from ..core import (
+    Context,
+    Data,
+    Node,
+    Params,
+    SequenceValue,
+    StringValue,
+    Value,
+)
+
+
+class BuildMappingParams(Params):
+    keys: SequenceValue[StringValue]
+
+
+class BuildMappingOutput(Data):
+    mapping: StringMapValue[Value]
+
+
+class BuildMappingNode(Node[Data, BuildMappingOutput, BuildMappingParams]):
+    type: Literal["BuildMapping"] = "BuildMapping"
+
+    @property
+    @override
+    def input_type(self) -> Type[Data]:
+        return build_data_type(
+            "BuildMappingInput",
+            {key.root: (Value, True) for key in self.params.keys.root},
+        )
+
+    @property
+    @override
+    def output_type(self) -> Type[BuildMappingOutput]:
+        return BuildMappingOutput
+
+    @override
+    async def run(self, context: Context, input: Data) -> BuildMappingOutput:
+        return BuildMappingOutput(
+            mapping=StringMapValue(
+                {key.root: getattr(input, key.root) for key in self.params.keys.root}
+            )
+        )
+
+    @classmethod
+    def from_keys(
+        cls,
+        node_id: str,
+        keys: Sequence[str],
+    ) -> Self:
+        return cls(
+            id=node_id,
+            params=BuildMappingParams(
+                keys=SequenceValue(root=[StringValue(key) for key in keys])
+            ),
+        )
+
+
+class ExtractKeyInput(Data):
+    mapping: StringMapValue[Value]
+
+
+class ExtractKeyParams(Params):
+    key: StringValue
+
+
+class ExtractKeyOutput(Data):
+    value: Value
+
+
+class ExtractKeyNode(Node[ExtractKeyInput, ExtractKeyOutput, ExtractKeyParams]):
+    type: Literal["ExtractKey"] = "ExtractKey"
+
+    @property
+    @override
+    def input_type(self) -> Type[ExtractKeyInput]:
+        return ExtractKeyInput
+
+    @property
+    @override
+    def output_type(self) -> Type[ExtractKeyOutput]:
+        return ExtractKeyOutput
+
+    @override
+    async def run(self, context: Context, input: ExtractKeyInput) -> ExtractKeyOutput:
+        return ExtractKeyOutput(value=input.mapping.root[self.params.key.root])
+
+    @classmethod
+    def from_key(cls, node_id: str, key: str) -> Self:
+        return cls(
+            id=node_id,
+            params=ExtractKeyParams(key=StringValue(key)),
+        )
+
+
+__all__ = [
+    "BuildMappingNode",
+    "ExtractKeyNode",
+]

--- a/src/workflow_engine/utils/iter.py
+++ b/src/workflow_engine/utils/iter.py
@@ -10,6 +10,16 @@ def only(it: Iterable[T]) -> T:
     return x
 
 
+def same(it: Iterable[T]) -> T:
+    it = iter(it)
+    x = next(it)
+    for y in it:
+        if x != y:
+            raise ValueError("Values are not the same")
+    return x
+
+
 __all__ = [
     "only",
+    "same",
 ]

--- a/src/workflow_engine/utils/mappings.py
+++ b/src/workflow_engine/utils/mappings.py
@@ -1,0 +1,39 @@
+# workflow_engine/utils/mappings.py
+
+from collections.abc import Mapping
+
+from functools import reduce
+from typing import TypeVar
+
+from .iter import same
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def mapping_intersection(
+    *mappings: Mapping[K, V],
+) -> Mapping[K, V]:
+    """
+    Computes the intersection of the given mappings, which consists of the keys
+    in common to all mappings.
+
+    For each key in the intersection, the associated value must be the same
+    across all mappings.
+    """
+    if len(mappings) == 0:
+        return {}
+    if len(mappings) == 1:
+        return mappings[0]
+
+    keys = reduce(
+        lambda acc, mapping: acc & set(mapping.keys()),
+        mappings[1:],
+        set(mappings[0].keys()),
+    )
+    return {key: same(mapping[key] for mapping in mappings) for key in keys}
+
+
+__all__ = [
+    "mapping_intersection",
+]

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -1,0 +1,262 @@
+import pytest
+
+from workflow_engine import (
+    BooleanValue,
+    Edge,
+    FloatValue,
+    InputEdge,
+    IntegerValue,
+    OutputEdge,
+    Workflow,
+)
+from workflow_engine.contexts import InMemoryContext
+from workflow_engine.execution import TopologicalExecutionAlgorithm
+from workflow_engine.nodes import AddNode, ConstantIntegerNode
+from workflow_engine.nodes.conditional import IfElseNode
+
+
+@pytest.fixture
+def add_one_workflow() -> Workflow:
+    """Create a workflow that adds one to a number."""
+
+    return Workflow(
+        nodes=[
+            one := ConstantIntegerNode.from_value(
+                node_id="one",
+                value=1,
+            ),
+            add_one := AddNode(id="add_one"),
+        ],
+        edges=[
+            Edge(
+                source_id=one.id,
+                source_key="value",
+                target_id=add_one.id,
+                target_key="b",
+            ),
+        ],
+        input_edges=[
+            InputEdge(
+                input_key="start",
+                target_id=add_one.id,
+                target_key="a",
+            ),
+        ],
+        output_edges=[
+            OutputEdge(
+                source_id=add_one.id,
+                source_key="sum",
+                output_key="result",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def subtract_one_workflow() -> Workflow:
+    """Create a workflow that subtracts one from a number."""
+
+    return Workflow(
+        nodes=[
+            negative_one := ConstantIntegerNode.from_value(
+                node_id="negative_one",
+                value=-1,
+            ),
+            subtract_one := AddNode(id="subtract_one"),
+        ],
+        edges=[
+            Edge(
+                source_id=negative_one.id,
+                source_key="value",
+                target_id=subtract_one.id,
+                target_key="b",
+            ),
+        ],
+        input_edges=[
+            InputEdge(
+                input_key="start",
+                target_id=subtract_one.id,
+                target_key="a",
+            ),
+        ],
+        output_edges=[
+            OutputEdge(
+                source_id=subtract_one.id,
+                source_key="sum",
+                output_key="result",
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_conditional_workflow(
+    add_one_workflow: Workflow,
+    subtract_one_workflow: Workflow,
+):
+    """Test that the workflow outputs start+1 when condition is True, and
+    start-1 when condition is False."""
+    context = InMemoryContext()
+    algorithm = TopologicalExecutionAlgorithm()
+
+    start_value = 42
+
+    workflow = Workflow(
+        nodes=[
+            conditional := IfElseNode.from_workflows(
+                node_id="conditional",
+                if_true=add_one_workflow,
+                if_false=subtract_one_workflow,
+            ),
+        ],
+        edges=[],
+        input_edges=[
+            InputEdge.from_node(
+                input_key="start",
+                target=conditional,
+                target_key="start",
+            ),
+            InputEdge.from_node(
+                input_key="condition",
+                target=conditional,
+                target_key="condition",
+            ),
+        ],
+        output_edges=[
+            OutputEdge.from_node(
+                source=conditional,
+                source_key="result",
+                output_key="result",
+            ),
+        ],
+    )
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "start": IntegerValue(start_value),
+            "condition": BooleanValue(False),
+        },
+    )
+    assert not errors.any(), errors
+    assert output == {"result": FloatValue(start_value - 1)}
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "start": IntegerValue(start_value),
+            "condition": BooleanValue(True),
+        },
+    )
+    assert not errors.any(), errors
+    assert output == {"result": FloatValue(start_value + 1)}
+
+
+@pytest.mark.asyncio
+async def test_conditional_workflow_twice_series(
+    add_one_workflow: Workflow,
+    subtract_one_workflow: Workflow,
+):
+    """Test that the workflow behaves correctly when condition is called twice
+    in series, once with True and once with False."""
+    context = InMemoryContext()
+    algorithm = TopologicalExecutionAlgorithm()
+
+    start_value = 42
+
+    workflow = Workflow(
+        nodes=[
+            conditional_1 := IfElseNode.from_workflows(
+                node_id="conditional_1",
+                if_true=add_one_workflow,
+                if_false=subtract_one_workflow,
+            ),
+            conditional_2 := IfElseNode.from_workflows(
+                node_id="conditional_2",
+                if_true=add_one_workflow,
+                if_false=subtract_one_workflow,
+            ),
+        ],
+        edges=[
+            Edge(
+                source_id=conditional_1.id,
+                source_key="result",
+                target_id=conditional_2.id,
+                target_key="start",
+            ),
+        ],
+        input_edges=[
+            InputEdge.from_node(
+                input_key="start",
+                target=conditional_1,
+                target_key="start",
+            ),
+            InputEdge.from_node(
+                input_key="condition_1",
+                target=conditional_1,
+                target_key="condition",
+            ),
+            InputEdge.from_node(
+                input_key="condition_2",
+                target=conditional_2,
+                target_key="condition",
+            ),
+        ],
+        output_edges=[
+            OutputEdge.from_node(
+                source=conditional_2,
+                source_key="result",
+                output_key="result",
+            ),
+        ],
+    )
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "start": IntegerValue(start_value),
+            "condition_1": BooleanValue(True),
+            "condition_2": BooleanValue(False),
+        },
+    )
+    assert not errors.any(), errors
+    assert output == {"result": FloatValue(start_value)}
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "start": IntegerValue(start_value),
+            "condition_1": BooleanValue(False),
+            "condition_2": BooleanValue(True),
+        },
+    )
+    assert not errors.any(), errors
+    assert output == {"result": FloatValue(start_value)}
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "start": IntegerValue(start_value),
+            "condition_1": BooleanValue(True),
+            "condition_2": BooleanValue(True),
+        },
+    )
+    assert not errors.any(), errors
+    assert output == {"result": FloatValue(start_value + 2)}
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "start": IntegerValue(start_value),
+            "condition_1": BooleanValue(False),
+            "condition_2": BooleanValue(False),
+        },
+    )
+    assert not errors.any(), errors
+    assert output == {"result": FloatValue(start_value - 2)}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,84 @@
+# tests/test_node.py
+from typing import Mapping
+import pytest
+
+from pydantic import ValidationError
+
+from workflow_engine.core.data import build_data_type, get_data_fields
+from workflow_engine.core.value import ValueType
+from workflow_engine import BooleanValue, Data, StringValue, IntegerValue
+
+
+@pytest.fixture
+def ExampleData() -> type[Data]:
+    """Test data class."""
+
+    class ExampleData(Data):
+        name: StringValue
+        age: IntegerValue
+        active: BooleanValue = None  # type: ignore
+
+    return ExampleData
+
+
+@pytest.fixture
+def example_fields() -> Mapping[str, tuple[ValueType, bool]]:
+    """Test fields."""
+
+    return {
+        "name": (StringValue, True),
+        "age": (IntegerValue, True),
+        "active": (BooleanValue, False),
+    }
+
+
+@pytest.mark.unit
+def test_get_data_fields(
+    ExampleData: type[Data], example_fields: Mapping[str, tuple[ValueType, bool]]
+):
+    """Test that get_data_fields returns the correct fields."""
+
+    assert get_data_fields(ExampleData) == example_fields
+
+
+@pytest.mark.unit
+def test_build_data_type(
+    ExampleData: type[Data], example_fields: Mapping[str, tuple[ValueType, bool]]
+):
+    """Test that build_data_type returns the correct class."""
+
+    cls = build_data_type("ExampleData", example_fields)
+
+    # can't exactly just test equality, instead we need to test that both
+    # classes behave identically in instantiation, serialization, etc.
+    assert cls.__name__ == ExampleData.__name__
+
+    # Test that the class can be instantiated
+    example_data = {
+        "name": "John",
+        "age": 30,
+        "active": True,
+    }
+
+    # Test that each class behaves the same way when instantiating the data
+    for kls in (cls, ExampleData):
+        instance = kls(name="John", age=30, active=True)  # type: ignore
+        deserialized = kls.model_validate(example_data)
+
+        assert instance == deserialized
+        assert instance.model_dump() == deserialized.model_dump() == example_data
+
+        # missing optional field
+        kls(name="John", age=30)  # type: ignore
+
+        # missing required field
+        with pytest.raises(ValidationError):
+            kls(name="John", active=True)  # type: ignore
+
+        # bad type
+        with pytest.raises(ValidationError):
+            kls(name="John", age="thirty", active=True)  # type: ignore
+
+        # extra field
+        with pytest.raises(ValidationError):
+            kls(name="John", age=30, active=True, extra=1)  # type: ignore


### PR DESCRIPTION
Composite nodes are a loosening of the Node interface to allow a node to return a workflow (subgraph).
If it does, then it is up to the execution engine to replace the node with the returned subgraph, simulating a function call.

This can be used to make dynamic decisions about the execution graph at runtime, as demonstrated in the `IfNode` and its more useful older sister the `IfElseNode`, which select or prune between candidate workflows depending on a boolean condition.
This PR is complex enough as it is, so I will leave the task of the `MapNode` implementation to a later PR.
However, as a reviewer, this PR should only be considered successful if it convinces you that a `MapNode` would fit cleanly into this system.
(I originally had a different implementation for `MapNode`, but after a few shower thoughts I realized this is the better way.)

There is some limited ability to infer the type of the node based on the type of the inner workflow(s), but it is rapidly descending into a Pydantic doom spiral. We might fix this later if it continues to develop into bigger concerns.


