### PR TITLE
Miscellaneous quality-of-life improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,3 @@ ruff = "^0.11.8"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.pyright]
-reportIncompatibleVariableOverride = false # too many false positives on Node subclasses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "workflow-engine"
-version = "0.3.0"
+version = "0.3.1"
 description = "A simple engine to execute workflows defined as JSON graphs"
 readme = "README.md"
 authors = [

--- a/src/workflow_engine/__init__.py
+++ b/src/workflow_engine/__init__.py
@@ -5,6 +5,7 @@ from .core import (
     Caster,
     Context,
     Data,
+    DataMapping,
     DataValue,
     Edge,
     Empty,
@@ -23,6 +24,8 @@ from .core import (
     StringMapValue,
     StringValue,
     UserException,
+    Value,
+    ValueType,
     Workflow,
     WorkflowErrors,
 )
@@ -32,6 +35,7 @@ __all__ = [
     "Caster",
     "Context",
     "Data",
+    "DataMapping",
     "DataValue",
     "Edge",
     "Empty",
@@ -50,6 +54,8 @@ __all__ = [
     "StringMapValue",
     "StringValue",
     "UserException",
+    "Value",
+    "ValueType",
     "Workflow",
     "WorkflowErrors",
 ]

--- a/src/workflow_engine/contexts/in_memory.py
+++ b/src/workflow_engine/contexts/in_memory.py
@@ -22,7 +22,7 @@ class InMemoryContext(Context):
         self,
         file: FileValue,
     ) -> bytes:
-        return self.data[file.root.path]
+        return self.data[file.path]
 
     @override
     async def write(
@@ -30,7 +30,7 @@ class InMemoryContext(Context):
         file: F,
         content: bytes,
     ) -> F:
-        self.data[file.root.path] = content
+        self.data[file.path] = content
         return file
 
 

--- a/src/workflow_engine/contexts/local.py
+++ b/src/workflow_engine/contexts/local.py
@@ -83,14 +83,14 @@ class LocalContext(Context):
         self,
         file: FileValue,
     ) -> bytes:
-        path = self.get_file_path(file.root.path)
+        path = self.get_file_path(file.path)
         if not os.path.exists(path):
-            raise UserException(f"File {file.root.path} not found")
+            raise UserException(f"File {file.path} not found")
         try:
             with open(path, "rb") as f:
                 return f.read()
         except Exception as e:
-            raise UserException(f"Failed to read file {file.root.path}") from e
+            raise UserException(f"Failed to read file {file.path}") from e
 
     @override
     async def write(
@@ -98,13 +98,13 @@ class LocalContext(Context):
         file: F,
         content: bytes,
     ) -> F:
-        path = self.get_file_path(file.root.path)
+        path = self.get_file_path(file.path)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         try:
             with open(path, "wb") as f:
                 f.write(content)
         except Exception as e:
-            raise UserException(f"Failed to write file {file.root.path}") from e
+            raise UserException(f"Failed to write file {file.path}") from e
         return file
 
     @override

--- a/src/workflow_engine/core/data.py
+++ b/src/workflow_engine/core/data.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict, create_model
 
@@ -37,7 +37,7 @@ class Data(BaseModel):
         return data
 
 
-DataMapping: TypeAlias = Mapping[str, Value]
+type DataMapping = Mapping[str, Value]
 
 
 def dump_data_mapping(data: DataMapping) -> Mapping[str, Any]:

--- a/src/workflow_engine/core/data.py
+++ b/src/workflow_engine/core/data.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, create_model
 
@@ -52,7 +52,7 @@ Input_contra = TypeVar("Input_contra", bound=Data, contravariant=True)
 Output_co = TypeVar("Output_co", bound=Data, covariant=True)
 
 
-def get_data_fields(cls: type[Data]) -> Mapping[str, tuple[ValueType, bool]]:
+def get_data_fields(cls: Type[Data]) -> Mapping[str, tuple[ValueType, bool]]:
     """
     Extract the fields of a Data subclass.
 
@@ -76,8 +76,8 @@ D = TypeVar("D", bound=Data)
 def build_data_type(
     name: str,
     fields: Mapping[str, tuple[ValueType, bool]],
-    base_cls: type[D] = Data,
-) -> type[D]:
+    base_cls: Type[D] = Data,
+) -> Type[D]:
     """
     Create a Data subclass whose fields are given by a mapping of field names to
     (ValueType, is_required) tuples.
@@ -118,8 +118,8 @@ V = TypeVar("V", bound=Value)
 
 @DataValue.register_generic_cast_to(DataValue)
 def cast_data_to_data(
-    source_type: type[DataValue],
-    target_type: type[DataValue],
+    source_type: Type[DataValue],
+    target_type: Type[DataValue],
 ) -> Caster[DataValue, DataValue] | None:
     source_origin, (source_value_type,) = get_origin_and_args(source_type)
     assert source_origin is DataValue
@@ -160,8 +160,8 @@ def cast_data_to_data(
 
 @DataValue.register_generic_cast_to(StringMapValue)
 def cast_data_to_string_map(
-    source_type: type[DataValue],
-    target_type: type[StringMapValue[V]],
+    source_type: Type[DataValue],
+    target_type: Type[StringMapValue[V]],
 ) -> Caster[DataValue, StringMapValue[V]] | None:
     """
     Casts a DataValue[D] object to a StringMapValue[V] object, if all of the
@@ -199,8 +199,8 @@ def cast_data_to_string_map(
 
 @StringMapValue.register_generic_cast_to(DataValue)
 def cast_string_map_to_data(
-    source_type: type[StringMapValue],
-    target_type: type[DataValue],
+    source_type: Type[StringMapValue],
+    target_type: Type[DataValue],
 ) -> Caster[StringMapValue, DataValue] | None:
     """
     Casts a StringMapValue[V] object to a DataValue[D] object by trying to cast

--- a/src/workflow_engine/core/file.py
+++ b/src/workflow_engine/core/file.py
@@ -18,7 +18,7 @@ class File(BaseModel, ABC):
     A Context provides the actual implementation to read the file's contents.
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra="forbid")
     metadata: Mapping[str, Any] = Field(default_factory=dict)
     mime_type: ClassVar[str]
     path: str
@@ -47,6 +47,10 @@ class FileValue(Value[File]):
         metadata = dict(self.root.metadata)
         metadata[key] = value
         return type(self)(self.root.model_copy(update={"metadata": metadata}))
+
+    @classmethod
+    def from_path(cls, path: str, **metadata: Any) -> Self:
+        return cls(root=File(path=path, metadata=metadata))
 
 
 __all__ = [

--- a/src/workflow_engine/core/file.py
+++ b/src/workflow_engine/core/file.py
@@ -23,7 +23,6 @@ class File(BaseModel, ABC):
 
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra="forbid")
     metadata: Mapping[str, Any] = Field(default_factory=dict)
-    mime_type: ClassVar[str]
     path: str
 
 
@@ -31,6 +30,8 @@ class FileValue(Value[File]):
     """
     A Value that represents a file.
     """
+
+    mime_type: ClassVar[str]
 
     async def read(self, context: "Context") -> bytes:
         return await context.read(file=self)
@@ -74,10 +75,6 @@ class FileValue(Value[File]):
     @property
     def path(self) -> str:
         return self.root.path
-
-    @property
-    def mime_type(self) -> str:
-        return self.root.mime_type
 
     @property
     def metadata(self) -> Mapping[str, Any]:

--- a/src/workflow_engine/core/file.py
+++ b/src/workflow_engine/core/file.py
@@ -76,6 +76,10 @@ class FileValue(Value[File]):
         return self.root.path
 
     @property
+    def mime_type(self) -> str:
+        return self.root.mime_type
+
+    @property
     def metadata(self) -> Mapping[str, Any]:
         return self.root.metadata
 

--- a/src/workflow_engine/core/file.py
+++ b/src/workflow_engine/core/file.py
@@ -55,7 +55,7 @@ class FileValue(Value[File]):
             old_value = self.metadata[key]
             if old_value == value:
                 return self
-            elif overwrite:
+            elif not overwrite:
                 raise ValueError(
                     f"Metadata key {key} already exists with value {old_value}, which is different from the new value {value}. Pass overwrite=True to overwrite."
                 )

--- a/src/workflow_engine/core/value.py
+++ b/src/workflow_engine/core/value.py
@@ -226,7 +226,7 @@ class Value(RootModel[T], Generic[T]):
         """
         return cls.get_caster(t) is not None
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, Value):
             return self.root == other.root
         return self.root == other

--- a/src/workflow_engine/core/value.py
+++ b/src/workflow_engine/core/value.py
@@ -227,9 +227,9 @@ class Value(RootModel[T], Generic[T]):
         return cls.get_caster(t) is not None
 
     def __eq__(self, other):
-        if not isinstance(other, Value):
-            return False
-        return self.root == other.root
+        if isinstance(other, Value):
+            return self.root == other.root
+        return self.root == other
 
     def __hash__(self):
         return hash(self.root)

--- a/src/workflow_engine/core/value.py
+++ b/src/workflow_engine/core/value.py
@@ -288,15 +288,27 @@ class FloatValue(Value[float]):
 
 
 class StringValue(Value[str]):
-    pass
+    def __len__(self) -> int:
+        return len(self.root)
 
 
 class SequenceValue(Value[Sequence[V]], Generic[V]):
-    pass
+    def __getitem__(self, index: int) -> V:
+        return self.root[index]
+
+    def __len__(self) -> int:
+        return len(self.root)
 
 
 class StringMapValue(Value[Mapping[str, V]], Generic[V]):
-    pass
+    def __getitem__(self, key: str) -> V:
+        return self.root[key]
+
+    def get(self, key: str, default: V | None = None) -> V | None:
+        return self.root.get(key, default)
+
+    def __len__(self) -> int:
+        return len(self.root)
 
 
 @IntegerValue.register_cast_to(FloatValue)

--- a/src/workflow_engine/files/json.py
+++ b/src/workflow_engine/files/json.py
@@ -5,10 +5,10 @@ from collections.abc import Sequence
 from typing import Any, Self, Type
 
 from ..core import (
-    File,
     BooleanValue,
     Caster,
     Context,
+    File,
     FloatValue,
     IntegerValue,
     NullValue,
@@ -186,7 +186,7 @@ async def cast_sequence_to_json_lines(
     context: "Context",
 ) -> JSONLinesFileValue:
     file = JSONLinesFileValue(File(path=f"{value.md5}.jsonl"))
-    return await file.write_data(context, [v.model_dump() for v in value.root])
+    return await file.write_data(context, [v.model_dump() for v in value])
 
 
 __all__ = [

--- a/src/workflow_engine/files/json.py
+++ b/src/workflow_engine/files/json.py
@@ -2,7 +2,7 @@
 import datetime
 import json
 from collections.abc import Sequence
-from typing import Any, Self, Type
+from typing import Any, ClassVar, Self, Type
 
 from ..core import (
     BooleanValue,
@@ -32,6 +32,8 @@ class JSONFileValue(TextFileValue):
     """
     A Value that represents a JSON file.
     """
+
+    mime_type: ClassVar[str] = "application/json"
 
     async def read_data(self, context: "Context") -> Any:
         return json.loads(await self.read_text(context))
@@ -121,6 +123,8 @@ class JSONLinesFileValue(TextFileValue):
     """
     A file that contains a list of Python objects serialized as JSON.
     """
+
+    mime_type: ClassVar[str] = "application/jsonl"
 
     async def read_data(self, context: "Context") -> Sequence[Any]:
         return [

--- a/src/workflow_engine/files/pdf.py
+++ b/src/workflow_engine/files/pdf.py
@@ -1,9 +1,11 @@
 # workflow_engine/files/pdf.py
+from typing import ClassVar
+
 from ..core import FileValue
 
 
 class PDFFileValue(FileValue):
-    pass
+    mime_type: ClassVar[str] = "application/pdf"
 
 
 __all__ = [

--- a/src/workflow_engine/files/text.py
+++ b/src/workflow_engine/files/text.py
@@ -1,10 +1,12 @@
 # workflow_engine/files/text.py
-from typing import Self
+from typing import ClassVar, Self
 
 from ..core import Context, File, FileValue, StringValue
 
 
 class TextFileValue(FileValue):
+    mime_type: ClassVar[str] = "text/plain"
+
     async def read_text(self, context: "Context") -> str:
         return (await self.read(context)).decode("utf-8")
 

--- a/src/workflow_engine/nodes/arithmetic.py
+++ b/src/workflow_engine/nodes/arithmetic.py
@@ -61,7 +61,7 @@ class SumNode(Node[SumNodeInput, SumNodeOutput, Empty]):
         return SumNodeOutput
 
     async def run(self, context: Context, input: SumNodeInput) -> SumNodeOutput:
-        return SumNodeOutput(sum=FloatValue(sum(v.root for v in input.values.root)))
+        return SumNodeOutput(sum=FloatValue(sum(v.root for v in input.values)))
 
 
 class IntegerData(Data):

--- a/src/workflow_engine/nodes/arithmetic.py
+++ b/src/workflow_engine/nodes/arithmetic.py
@@ -27,7 +27,7 @@ class SumOutput(Data):
 
 
 class AddNode(Node[AddNodeInput, SumOutput, Empty]):
-    type: Literal["Add"] = "Add"
+    type: Literal["Add"] = "Add"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def input_type(self):
@@ -50,7 +50,7 @@ class SumNodeOutput(Data):
 
 
 class SumNode(Node[SumNodeInput, SumNodeOutput, Empty]):
-    type: Literal["Sum"] = "Sum"
+    type: Literal["Sum"] = "Sum"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def input_type(self):
@@ -73,7 +73,7 @@ class FactorizationData(Data):
 
 
 class FactorizationNode(Node[IntegerData, FactorizationData, Params]):
-    type: Literal["Factorization"] = "Factorization"
+    type: Literal["Factorization"] = "Factorization"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def input_type(self):

--- a/src/workflow_engine/nodes/conditional.py
+++ b/src/workflow_engine/nodes/conditional.py
@@ -48,7 +48,7 @@ class IfNode(Node[ConditionalInput, Empty, IfParams]):
 
     # TODO: allow conditional nodes with optional output
 
-    type: Literal["If"] = "If"
+    type: Literal["If"] = "If"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     @override
@@ -90,7 +90,7 @@ class IfElseNode(Node[ConditionalInput, Data, IfElseParams]):
 
     # TODO: allow union types
 
-    type: Literal["IfElse"] = "IfElse"
+    type: Literal["IfElse"] = "IfElse"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     @override

--- a/src/workflow_engine/nodes/conditional.py
+++ b/src/workflow_engine/nodes/conditional.py
@@ -14,10 +14,10 @@ from ..core import (
     BooleanValue,
     Context,
     Data,
-    Workflow,
     Empty,
     Node,
     Params,
+    Workflow,
 )
 from ..utils.mappings import mapping_intersection
 

--- a/src/workflow_engine/nodes/constant.py
+++ b/src/workflow_engine/nodes/constant.py
@@ -18,7 +18,7 @@ class ConstantBoolean(Params):
 
 
 class ConstantBooleanNode(Node[Empty, ConstantBoolean, ConstantBoolean]):
-    type: Literal["ConstantBoolean"] = "ConstantBoolean"
+    type: Literal["ConstantBoolean"] = "ConstantBoolean"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def output_type(self) -> Type[ConstantBoolean]:
@@ -37,7 +37,7 @@ class ConstantInteger(Params):
 
 
 class ConstantIntegerNode(Node[Empty, ConstantInteger, ConstantInteger]):
-    type: Literal["ConstantInteger"] = "ConstantInteger"
+    type: Literal["ConstantInteger"] = "ConstantInteger"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def output_type(self) -> Type[ConstantInteger]:
@@ -56,7 +56,7 @@ class ConstantString(Params):
 
 
 class ConstantStringNode(Node[Empty, ConstantString, ConstantString]):
-    type: Literal["ConstantString"] = "ConstantString"
+    type: Literal["ConstantString"] = "ConstantString"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def output_type(self) -> Type[ConstantString]:

--- a/src/workflow_engine/nodes/data.py
+++ b/src/workflow_engine/nodes/data.py
@@ -52,7 +52,7 @@ class GatherSequenceNode(Node[Data, SequenceData, SequenceParams]):
         {"sequence": [0, 1, 2]}
     """
 
-    type: Literal["GatherSequence"] = "GatherSequence"
+    type: Literal["GatherSequence"] = "GatherSequence"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the elements in the sequence.
     # For now, this field is only available when the node is constructed
@@ -108,7 +108,7 @@ class ExpandSequenceNode(Node[SequenceData, Data, SequenceParams]):
     Extracts a sequence of elements to a data object.
     """
 
-    type: Literal["ExpandSequence"] = "ExpandSequence"
+    type: Literal["ExpandSequence"] = "ExpandSequence"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the element to extract.
     # For now, this field is only available when the node is constructed
@@ -185,7 +185,7 @@ class GatherMappingNode(Node[Data, MappingData, MappingParams]):
         {"mapping": {"a": 1, "b": 2, "c": 3}}
     """
 
-    type: Literal["GatherMapping"] = "GatherMapping"
+    type: Literal["GatherMapping"] = "GatherMapping"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the values in the mapping.
     # For now, this field is only available when the node is constructed
@@ -238,7 +238,7 @@ class ExpandMappingNode(Node[MappingData, Data, MappingParams]):
         {"a": 1, "b": 2, "c": 3}
     """
 
-    type: Literal["ExpandMapping"] = "ExpandMapping"
+    type: Literal["ExpandMapping"] = "ExpandMapping"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the values in the mapping.
     # For now, this field is only available when the node is constructed
@@ -300,7 +300,7 @@ class GatherDataNode(Node[Data, NestedData, Empty]):
         {"data": {"a": 1, "b": 2, "c": 3}}
     """
 
-    type: Literal["GatherData"] = "GatherData"
+    type: Literal["GatherData"] = "GatherData"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the element to extract.
     # For now, this field is only available when the node is constructed
@@ -341,7 +341,7 @@ class ExpandDataNode(Node[NestedData, Data, Empty]):
         {"a": 1, "b": 2, "c": 3}
     """
 
-    type: Literal["ExpandData"] = "ExpandData"
+    type: Literal["ExpandData"] = "ExpandData"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the nested data object.
     # For now, this field is only available when the node is constructed

--- a/src/workflow_engine/nodes/error.py
+++ b/src/workflow_engine/nodes/error.py
@@ -26,7 +26,7 @@ class ErrorNode(Node[ErrorInput, Empty, ErrorParams]):
     A node that always raises an error.
     """
 
-    type: Literal["Error"] = "Error"
+    type: Literal["Error"] = "Error"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def input_type(self):

--- a/src/workflow_engine/nodes/error.py
+++ b/src/workflow_engine/nodes/error.py
@@ -7,8 +7,8 @@ from ..core import (
     Data,
     Empty,
     Node,
-    StringValue,
     Params,
+    StringValue,
     UserException,
 )
 

--- a/src/workflow_engine/nodes/iteration.py
+++ b/src/workflow_engine/nodes/iteration.py
@@ -12,8 +12,8 @@ from ..core import (
     DataValue,
     Edge,
     InputEdge,
-    OutputEdge,
     Node,
+    OutputEdge,
     Params,
     Workflow,
 )
@@ -59,7 +59,7 @@ class ForEachNode(Node[SequenceData, SequenceData, ForEachParams]):
 
     @override
     async def run(self, context: Context, input: SequenceData) -> Workflow:
-        N = len(input.sequence.root)
+        N = len(input.sequence)
         workflow = self.params.workflow
 
         nodes: list[Node] = []

--- a/src/workflow_engine/nodes/iteration.py
+++ b/src/workflow_engine/nodes/iteration.py
@@ -45,7 +45,7 @@ class ForEachNode(Node[SequenceData, SequenceData, ForEachParams]):
     sequence, with each item being the output of the internal workflow.
     """
 
-    type: Literal["ForEach"] = "ForEach"
+    type: Literal["ForEach"] = "ForEach"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     @override

--- a/src/workflow_engine/nodes/text.py
+++ b/src/workflow_engine/nodes/text.py
@@ -27,7 +27,7 @@ class AppendToFileParams(Params):
 
 
 class AppendToFileNode(Node[AppendToFileInput, AppendToFileOutput, AppendToFileParams]):
-    type: Literal["AppendToFile"] = "AppendToFile"
+    type: Literal["AppendToFile"] = "AppendToFile"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
     def input_type(self):

--- a/src/workflow_engine/nodes/text.py
+++ b/src/workflow_engine/nodes/text.py
@@ -44,7 +44,7 @@ class AppendToFileNode(Node[AppendToFileInput, AppendToFileOutput, AppendToFileP
     ) -> AppendToFileOutput:
         old_text = await input.file.read_text(context)
         new_text = old_text + input.text.root
-        filename, ext = os.path.splitext(input.file.root.path)
+        filename, ext = os.path.splitext(input.file.path)
         new_file = TextFileValue(File(path=filename + self.params.suffix.root + ext))
         new_file = await new_file.write_text(context, text=new_text)
         return AppendToFileOutput(file=new_file)

--- a/tests/test_addition.py
+++ b/tests/test_addition.py
@@ -2,7 +2,6 @@ import pytest
 
 from workflow_engine import (
     Edge,
-    FloatValue,
     InputEdge,
     IntegerValue,
     OutputEdge,
@@ -86,4 +85,4 @@ async def test_workflow_execution(workflow: Workflow):
         input={"c": IntegerValue(c)},
     )
     assert not errors.any()
-    assert output == {"sum": FloatValue(42 + 2025 + c)}
+    assert output == {"sum": 42 + 2025 + c}

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -69,6 +69,6 @@ async def test_workflow_execution(workflow: Workflow):
     # Verify the output file exists and has the correct content
     output_file = output["file"]
     assert isinstance(output_file, TextFileValue)
-    assert output_file.root.path == "test_append.txt"
+    assert output_file.path == "test_append.txt"
     output_text = await output_file.read_text(context)
     assert output_text == hello_world + appended_text.root

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -3,7 +3,6 @@ import pytest
 from workflow_engine import (
     BooleanValue,
     Edge,
-    FloatValue,
     InputEdge,
     IntegerValue,
     OutputEdge,
@@ -134,7 +133,7 @@ async def test_conditional_workflow(
         },
     )
     assert not errors.any(), errors
-    assert output == {"result": FloatValue(start_value - 1)}
+    assert output == {"result": start_value - 1}
 
     errors, output = await algorithm.execute(
         context=context,
@@ -145,7 +144,7 @@ async def test_conditional_workflow(
         },
     )
     assert not errors.any(), errors
-    assert output == {"result": FloatValue(start_value + 1)}
+    assert output == {"result": start_value + 1}
 
 
 @pytest.mark.asyncio
@@ -217,7 +216,7 @@ async def test_conditional_workflow_twice_series(
         },
     )
     assert not errors.any(), errors
-    assert output == {"result": FloatValue(start_value)}
+    assert output == {"result": start_value}
 
     errors, output = await algorithm.execute(
         context=context,
@@ -229,7 +228,7 @@ async def test_conditional_workflow_twice_series(
         },
     )
     assert not errors.any(), errors
-    assert output == {"result": FloatValue(start_value)}
+    assert output == {"result": start_value}
 
     errors, output = await algorithm.execute(
         context=context,
@@ -241,7 +240,7 @@ async def test_conditional_workflow_twice_series(
         },
     )
     assert not errors.any(), errors
-    assert output == {"result": FloatValue(start_value + 2)}
+    assert output == {"result": start_value + 2}
 
     errors, output = await algorithm.execute(
         context=context,
@@ -253,4 +252,4 @@ async def test_conditional_workflow_twice_series(
         },
     )
     assert not errors.any(), errors
-    assert output == {"result": FloatValue(start_value - 2)}
+    assert output == {"result": start_value - 2}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,12 +1,12 @@
 # tests/test_node.py
 from collections.abc import Mapping
-import pytest
 
+import pytest
 from pydantic import ValidationError
 
+from workflow_engine import BooleanValue, Data, IntegerValue, StringValue
 from workflow_engine.core.data import build_data_type, get_data_fields
 from workflow_engine.core.value import ValueType
-from workflow_engine import BooleanValue, Data, StringValue, IntegerValue
 
 
 @pytest.fixture

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,5 @@
 # tests/test_node.py
-from typing import Mapping
+from collections.abc import Mapping
 import pytest
 
 from pydantic import ValidationError

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
 # tests/test_node.py
 from collections.abc import Mapping
+from typing import Type
 
 import pytest
 from pydantic import ValidationError
@@ -10,7 +11,7 @@ from workflow_engine.core.value import ValueType
 
 
 @pytest.fixture
-def ExampleData() -> type[Data]:
+def ExampleData() -> Type[Data]:
     """Test data class."""
 
     class ExampleData(Data):
@@ -34,7 +35,8 @@ def example_fields() -> Mapping[str, tuple[ValueType, bool]]:
 
 @pytest.mark.unit
 def test_get_data_fields(
-    ExampleData: type[Data], example_fields: Mapping[str, tuple[ValueType, bool]]
+    ExampleData: Type[Data],
+    example_fields: Mapping[str, tuple[ValueType, bool]],
 ):
     """Test that get_data_fields returns the correct fields."""
 
@@ -43,7 +45,8 @@ def test_get_data_fields(
 
 @pytest.mark.unit
 def test_build_data_type(
-    ExampleData: type[Data], example_fields: Mapping[str, tuple[ValueType, bool]]
+    ExampleData: Type[Data],
+    example_fields: Mapping[str, tuple[ValueType, bool]],
 ):
     """Test that build_data_type returns the correct class."""
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -21,7 +21,7 @@ def context():
 @pytest.mark.unit
 async def test_cast_jsonlines_to_sequence(context: Context):
     """Test that JSONLinesFileValue can be cast to a SequenceValue."""
-    jsonl_file = JSONLinesFileValue(File(path="input.jsonl"))
+    jsonl_file = JSONLinesFileValue.from_path("input.jsonl")
 
     await jsonl_file.write_data(context, [{"a": 1}, {"b": 2}, {"c": 3}])
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -22,22 +22,18 @@ def context():
 async def test_cast_jsonlines_to_sequence(context: Context):
     """Test that JSONLinesFileValue can be cast to a SequenceValue."""
     jsonl_file = JSONLinesFileValue.from_path("input.jsonl")
+    contents = [{"a": 1}, {"b": 2}, {"c": 3}]
+    contents_str = '{"a": 1}\n{"b": 2}\n{"c": 3}'
 
-    await jsonl_file.write_data(context, [{"a": 1}, {"b": 2}, {"c": 3}])
+    await jsonl_file.write_data(context, contents)
 
-    assert (await jsonl_file.read_text(context)) == '{"a": 1}\n{"b": 2}\n{"c": 3}'
+    assert (await jsonl_file.read_text(context)) == contents_str
 
     data = await SequenceValue[StringMapValue[IntegerValue]].cast_from(
         jsonl_file,
         context=context,
     )
-    assert data == SequenceValue[StringMapValue[IntegerValue]](
-        [
-            StringMapValue({"a": IntegerValue(1)}),
-            StringMapValue({"b": IntegerValue(2)}),
-            StringMapValue({"c": IntegerValue(3)}),
-        ]
-    )
+    assert data == contents
 
     json_files = await SequenceValue[JSONFileValue].cast_from(
         jsonl_file,

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,15 +1,16 @@
 from hashlib import md5
+
 import pytest
 
 from workflow_engine import (
     Context,
     File,
     IntegerValue,
-    StringMapValue,
     SequenceValue,
+    StringMapValue,
 )
 from workflow_engine.contexts.in_memory import InMemoryContext
-from workflow_engine.files.json import JSONLinesFileValue, JSONFileValue
+from workflow_engine.files.json import JSONFileValue, JSONLinesFileValue
 
 
 @pytest.fixture
@@ -47,6 +48,6 @@ async def test_cast_jsonlines_to_sequence(context: Context):
             JSONFileValue(File(path=f"{md5(b"{'c': 3}").hexdigest()}.json")),
         ]
     )
-    assert (await json_files.root[0].read_data(context)) == {"a": 1}
-    assert (await json_files.root[1].read_data(context)) == {"b": 2}
-    assert (await json_files.root[2].read_data(context)) == {"c": 3}
+    assert (await json_files[0].read_data(context)) == {"a": 1}
+    assert (await json_files[1].read_data(context)) == {"b": 2}
+    assert (await json_files[2].read_data(context)) == {"c": 3}

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -27,19 +27,19 @@ def test_basic_value_creation():
     """Test basic Value creation and properties."""
     # Test StringValue
     str_val = StringValue("hello")
-    assert str_val.root == "hello"
+    assert str_val == "hello"
     assert isinstance(str_val, StringValue)
     assert isinstance(str_val, Value)
 
     # Test IntegerValue
     int_val = IntegerValue(42)
-    assert int_val.root == 42
+    assert int_val == 42
     assert isinstance(int_val, IntegerValue)
     assert isinstance(int_val, Value)
 
     # Test FloatValue
     float_val = FloatValue(3.14)
-    assert float_val.root == 3.14
+    assert float_val == 3.14
     assert isinstance(float_val, FloatValue)
     assert isinstance(float_val, Value)
 
@@ -119,17 +119,17 @@ async def test_sequence_value(context):
     int_sequence = SequenceValue[IntegerValue](
         [IntegerValue(1), IntegerValue(2), IntegerValue(3)]
     )
-    assert len(int_sequence.root) == 3
-    assert all(isinstance(x, IntegerValue) for x in int_sequence.root)
+    assert len(int_sequence) == 3
+    assert all(isinstance(x, IntegerValue) for x in int_sequence)
 
     # Cast to sequence of strings
     str_sequence = await int_sequence.cast_to(
         SequenceValue[StringValue], context=context
     )
     assert isinstance(str_sequence, SequenceValue)
-    assert len(str_sequence.root) == 3
-    assert all(isinstance(x, StringValue) for x in str_sequence.root)
-    assert [x.root for x in str_sequence.root] == ["1", "2", "3"]
+    assert len(str_sequence) == 3
+    assert all(isinstance(x, StringValue) for x in str_sequence)
+    assert str_sequence == ["1", "2", "3"]
 
     # Cast back to sequence of integers
     int_sequence_again = await str_sequence.cast_to(
@@ -149,15 +149,15 @@ async def test_string_map_value(context):
             "c": IntegerValue(3),
         }
     )
-    assert len(int_map.root) == 3
-    assert all(isinstance(v, IntegerValue) for v in int_map.root.values())
+    assert len(int_map) == 3
+    assert all(isinstance(v, IntegerValue) for v in int_map.values())
 
     # Cast to map of strings
     str_map = await int_map.cast_to(StringMapValue[StringValue], context=context)
     assert isinstance(str_map, StringMapValue)
-    assert len(str_map.root) == 3
-    assert all(isinstance(v, StringValue) for v in str_map.root.values())
-    assert {k: v.root for k, v in str_map.root.items()} == {
+    assert len(str_map) == 3
+    assert all(isinstance(v, StringValue) for v in str_map.values())
+    assert str_map == {
         "a": "1",
         "b": "2",
         "c": "3",
@@ -351,8 +351,8 @@ def test_sequence_value_json():
     # Test with simple sequence
     sequence_json = "[1, 2, 3]"
     sequence_val = SequenceValue[IntegerValue].model_validate_json(sequence_json)
-    assert len(sequence_val.root) == 3
-    assert [x.root for x in sequence_val.root] == [1, 2, 3]
+    assert len(sequence_val) == 3
+    assert sequence_val == [1, 2, 3]
 
     # Test serialization back to JSON
     json_str = sequence_val.model_dump_json()
@@ -365,8 +365,8 @@ def test_string_map_value_json():
     # Test with simple map
     map_json = '{"a": 1, "b": 2, "c": 3}'
     map_val = StringMapValue[IntegerValue].model_validate_json(map_json)
-    assert len(map_val.root) == 3
-    assert {k: v.root for k, v in map_val.root.items()} == {"a": 1, "b": 2, "c": 3}
+    assert len(map_val) == 3
+    assert map_val == {"a": 1, "b": 2, "c": 3}
 
     # Test serialization back to JSON
     json_str = map_val.model_dump_json()

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -91,25 +91,25 @@ async def test_basic_casting(context):
     int_val = IntegerValue(42)
     str_val = await int_val.cast_to(StringValue, context=context)
     assert isinstance(str_val, StringValue)
-    assert str_val.root == "42"
+    assert str_val == "42"
 
     # String to Integer
     str_val = StringValue("123")
     int_val = await str_val.cast_to(IntegerValue, context=context)
     assert isinstance(int_val, IntegerValue)
-    assert int_val.root == 123
+    assert int_val == 123
 
     # String to Float
     str_val = StringValue("3.14")
     float_val = await str_val.cast_to(FloatValue, context=context)
     assert isinstance(float_val, FloatValue)
-    assert float_val.root == 3.14
+    assert float_val == 3.14
 
     # Integer to Float
     int_val = IntegerValue(42)
     float_val = await int_val.cast_to(FloatValue, context=context)
     assert isinstance(float_val, FloatValue)
-    assert float_val.root == 42.0
+    assert float_val == 42.0
 
 
 @pytest.mark.unit
@@ -175,19 +175,19 @@ async def test_cast_from_class_method(context):
     int_val = IntegerValue(42)
     str_val = await StringValue.cast_from(int_val, context=context)
     assert isinstance(str_val, StringValue)
-    assert str_val.root == "42"
+    assert str_val == "42"
 
     # Test IntegerValue.cast_from
     str_val = StringValue("123")
     int_val = await IntegerValue.cast_from(str_val, context=context)
     assert isinstance(int_val, IntegerValue)
-    assert int_val.root == 123
+    assert int_val == 123
 
     # Test FloatValue.cast_from
     int_val = IntegerValue(42)
     float_val = await FloatValue.cast_from(int_val, context=context)
     assert isinstance(float_val, FloatValue)
-    assert float_val.root == 42.0
+    assert float_val == 42.0
 
 
 @pytest.mark.unit
@@ -197,7 +197,7 @@ async def test_cast_cache(context):
 
     # First cast should compute the result
     str_val1 = await int_val.cast_to(StringValue, context=context)
-    assert str_val1.root == "42"
+    assert str_val1 == "42"
 
     # Second cast should use cache
     str_val2 = await int_val.cast_to(StringValue, context=context)
@@ -314,7 +314,7 @@ async def test_cast_registration(context):
     assert QuestionValue.can_cast_to(AnswerValue)
     question = QuestionValue("the universe")
     answer = await question.cast_to(AnswerValue, context=context)
-    assert answer.root == 42
+    assert answer == 42
 
     # Try to register the same cast again (after casting operations)
     with pytest.raises(
@@ -400,12 +400,12 @@ async def test_async_caster_registration_and_usage(context):
     # Test async casting
     result = await test_value.cast_to(StringValue, context=context)
     assert isinstance(result, StringValue)
-    assert result.root == "converted: hello world"
+    assert result == "converted: hello world"
 
     # Test classmethod usage
     result_from = await StringValue.cast_from(test_value, context=context)
     assert isinstance(result_from, StringValue)
-    assert result_from.root == "converted: hello world"
+    assert result_from == "converted: hello world"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bumps workflow engine to v0.3.1

## Changes

- `Value`s can be annoying to use because you need to access their values via `.root`; to fix this we expose some obvious fields (e.g. `StringMapNode.items()`, `SequenceNode.__len__()` via properties on the `Value` wrapper so we don't always have to reach inside.
- One convenience method is `__eq__()`, making tests a lot easier to write
- Switched to always use `Type[...]` annotations instead of `type[...]`
- Always use the modern `type Alias = Definition` syntax for type aliases
- Restore missing MIME types
- Fill in some missing top-level exports