### PR TITLE
Add serializable metadata to node types

### DIFF
--- a/examples/addition.json
+++ b/examples/addition.json
@@ -2,6 +2,7 @@
   "nodes": [
     {
       "type": "ConstantInteger",
+      "version": "0.4.0",
       "id": "a",
       "params": {
         "value": 42
@@ -9,6 +10,7 @@
     },
     {
       "type": "ConstantInteger",
+      "version": "0.4.0",
       "id": "b",
       "params": {
         "value": 2025
@@ -16,11 +18,13 @@
     },
     {
       "type": "Add",
+      "version": "0.4.0",
       "id": "a+b",
       "params": {}
     },
     {
       "type": "Add",
+      "version": "0.4.0",
       "id": "a+b+c",
       "params": {}
     }

--- a/examples/append.json
+++ b/examples/append.json
@@ -2,6 +2,7 @@
   "nodes": [
     {
       "type": "AppendToFile",
+      "version": "0.4.0",
       "id": "append",
       "params": {
         "suffix": "_append"

--- a/examples/error.json
+++ b/examples/error.json
@@ -2,6 +2,7 @@
   "nodes": [
     {
       "type": "ConstantString",
+      "version": "0.4.0",
       "id": "constant",
       "params": {
         "value": "test"
@@ -9,6 +10,7 @@
     },
     {
       "type": "Error",
+      "version": "0.4.0",
       "id": "error",
       "params": {
         "error_name": "RuntimeError"

--- a/src/workflow_engine/core/__init__.py
+++ b/src/workflow_engine/core/__init__.py
@@ -5,7 +5,7 @@ from .edge import Edge, InputEdge, OutputEdge
 from .error import NodeException, UserException, WorkflowErrors
 from .execution import ExecutionAlgorithm
 from .file import File, FileValue
-from .node import Empty, Node, Params
+from .node import Empty, Node, NodeTypeInfo, Params
 from .value import (
     BooleanValue,
     Caster,
@@ -41,6 +41,7 @@ __all__ = [
     "JSONValue",
     "Node",
     "NodeException",
+    "NodeTypeInfo",
     "NullValue",
     "OutputEdge",
     "Params",

--- a/src/workflow_engine/core/data.py
+++ b/src/workflow_engine/core/data.py
@@ -3,9 +3,11 @@ import asyncio
 import json
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Type, TypeVar
 
-from pydantic import BaseModel, ConfigDict, create_model
+from pydantic import ConfigDict, create_model
+
+from workflow_engine.utils.immutable import ImmutableBaseModel
 
 from .value import Caster, StringMapValue, Value, ValueType, get_origin_and_args
 
@@ -15,8 +17,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Data(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+class Data(ImmutableBaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     def __init_subclass__(cls, **kwargs):
         """Ensure all fields in subclasses are Value types."""

--- a/src/workflow_engine/core/edge.py
+++ b/src/workflow_engine/core/edge.py
@@ -1,17 +1,15 @@
 # workflow_engine/core/edge.py
 
-from pydantic import BaseModel, ConfigDict
+from workflow_engine.utils.immutable import ImmutableBaseModel
 
 from .node import Node
 from .value import Value, ValueType
 
 
-class Edge(BaseModel):
+class Edge(ImmutableBaseModel):
     """
     An edge connects the output of source node to the input of a target node.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     source_id: str
     source_key: str
@@ -61,25 +59,21 @@ class Edge(BaseModel):
             )
 
 
-class SynchronizationEdge(BaseModel):
+class SynchronizationEdge(ImmutableBaseModel):
     """
     An edge that carries no information, but indicates that the target node must
     run after the source node finishes.
     """
 
-    model_config = ConfigDict(frozen=True)
-
     source_id: str
     target_id: str
 
 
-class InputEdge(BaseModel):
+class InputEdge(ImmutableBaseModel):
     """
     An "edge" that maps a field from the workflow's input to the input of a
     target node.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     input_key: str
     target_id: str
@@ -114,13 +108,11 @@ class InputEdge(BaseModel):
             )
 
 
-class OutputEdge(BaseModel):
+class OutputEdge(ImmutableBaseModel):
     """
     An "edge" that maps a source node's output to a special output of the
     workflow.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     source_id: str
     source_key: str

--- a/src/workflow_engine/core/error.py
+++ b/src/workflow_engine/core/error.py
@@ -3,7 +3,9 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
+
+from workflow_engine.utils.immutable import ImmutableBaseModel
 
 if TYPE_CHECKING:
     from .workflow import Workflow
@@ -68,7 +70,7 @@ class NodeExpansionException(UserException):
             return base_message
 
 
-class WorkflowErrors(BaseModel):
+class WorkflowErrors(ImmutableBaseModel):
     """
     An error object that accumulates the errors that occurred during the
     execution of a workflow.
@@ -79,7 +81,6 @@ class WorkflowErrors(BaseModel):
     node_errors contains errors which can be associated with a node.
     """
 
-    model_config = ConfigDict(frozen=True)
     workflow_errors: list[str | None] = Field(default_factory=list)
     node_errors: dict[str, list[str | None]] = Field(
         default_factory=lambda: defaultdict(list)

--- a/src/workflow_engine/core/file.py
+++ b/src/workflow_engine/core/file.py
@@ -4,7 +4,9 @@ from collections.abc import Mapping
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from workflow_engine.utils.immutable import ImmutableBaseModel
 
 from .value import Value
 
@@ -14,14 +16,14 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
-class File(BaseModel, ABC):
+class File(ImmutableBaseModel, ABC):
     """
     A serializable reference to a file.
 
     A Context provides the actual implementation to read the file's contents.
     """
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
     metadata: Mapping[str, Any] = Field(default_factory=dict)
     path: str
 

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -2,25 +2,34 @@
 import asyncio
 import logging
 import re
+import warnings
 from collections.abc import Mapping
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Awaitable,
+    ClassVar,
     Generic,
+    Literal,
     Self,
     Type,
     TypeVar,
-    Union,
     Unpack,
-    _LiteralGenericAlias,  # type: ignore
+    get_origin,
 )
 
 from overrides import final
-from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    model_validator,
+)
 
-if TYPE_CHECKING:
-    from .context import Context
-    from .workflow import Workflow
+from workflow_engine.utils.immutable import ImmutableBaseModel
+from workflow_engine.utils.semver import parse_semver
+
 from .data import (
     Data,
     DataMapping,
@@ -31,11 +40,15 @@ from .data import (
 from .error import NodeException, UserException
 from .value import Value, ValueType
 
+if TYPE_CHECKING:
+    from .context import Context
+    from .workflow import Workflow
+
 logger = logging.getLogger(__name__)
 
 
 class Params(Data):
-    model_config = ConfigDict(
+    model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="allow",
         frozen=True,
     )
@@ -65,37 +78,75 @@ class Empty(Params):
 generic_pattern = re.compile(r"^[a-zA-Z]\w+\[.*\]$")
 
 
-class Node(BaseModel, Generic[Input_contra, Output_co, Params_co]):
-    model_config = ConfigDict(
-        extra="forbid",
-        frozen=True,
+class NodeTypeInfo(BaseModel):
+    """
+    Information about a node type, in serializable form.
+    """
+
+    name: str = Field(
+        description="The name of the node type, which should be a literal string for concrete subclasses."
+    )
+    display_name: str = Field(
+        description="A human-readable display name for the node, which may or may not be unique."
+    )
+    description: str = Field(
+        description="A human-readable description of the node type."
+    )
+    version: str = Field(
+        description="A 3-part version number for the node, following semantic versioning rules (see https://semver.org/)."
     )
 
-    type: str  # should be a literal string for concrete subclasses
-    id: str
-    # contains any extra fields for configuring the node
-    params: Params_co = Empty()  # type: ignore
+    @cached_property
+    def version_tuple(self) -> tuple[int, int, int]:
+        return parse_semver(self.version)
 
-    @property
-    def input_type(self) -> Type[Input_contra]:  # type: ignore (contravariant return type)
-        # return Empty to spare users from having to specify the input type on
-        # nodes that don't have any input fields
-        return Empty  # type: ignore
 
-    @property
-    # @abstractmethod
-    def output_type(self) -> Type[Output_co]:
-        # return Empty to spare users from having to specify the output type on
-        # nodes that don't have any output fields
-        return Empty  # type: ignore
+class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
+    """
+    A data processing node in a workflow.
+    Nodes have three sets of fields:
+    - parameter fields must be provided when defining the workflow
+    - input fields are provided when executing the workflow
+    - output fields are produced by the node if it executes successfully
+    """
 
-    @property
-    def input_fields(self) -> Mapping[str, tuple[ValueType, bool]]:  # type: ignore
-        return get_data_fields(self.input_type)
+    # Allow extra fields, such as position or appearance information.
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 
-    @property
-    def output_fields(self) -> Mapping[str, tuple[ValueType, bool]]:
-        return get_data_fields(self.output_type)
+    # Must be annotated as ClassVar[NodeTypeInfo] when overriding
+    TYPE_INFO: ClassVar[NodeTypeInfo]
+
+    type: str = Field(
+        description=(
+            "The type of the node, which should be a literal string for discriminating concrete subclasses. "
+            "Used to determine which node class to load."
+        ),
+    )
+    version: str = Field(
+        description=(
+            "A 3-part version number for the node, following semantic versioning rules (see https://semver.org/). "
+            "There is no guarantee that outdated versions will load successfully. "
+            "If not provided, it will default to the current version of the node type."
+        ),
+        default="",
+    )
+    id: str = Field(
+        description="The ID of the node, which must be unique within the workflow."
+    )
+    params: Params_co = Field(
+        default_factory=Empty,  # type: ignore
+        description=(
+            "Any parameters for the node which are independent of the workflow inputs. "
+            "May affect what inputs are accepted by the node."
+        ),
+    )
+
+    # --------------------------------------------------------------------------
+    # SUBCLASS DISPATCH
+    # We use this trick to allow Node.model_validate to deserialize nodes as
+    # their registered subclasses, using the type field as a discriminator to
+    # select the appropriate subclass.
+    # Node subclasses are registered automatically when they are defined.
 
     def __init_subclass__(cls, **kwargs: Unpack[ConfigDict]):
         super().__init_subclass__(**kwargs)  # type: ignore
@@ -105,17 +156,12 @@ class Node(BaseModel, Generic[Input_contra, Output_co, Params_co]):
         while generic_pattern.match(cls.__name__) is not None:
             assert cls.__base__ is not None
             cls = cls.__base__
-        name = cls.__name__
-        assert name.endswith("Node"), name
         type_annotation = cls.__annotations__.get("type", None)
-        if type_annotation is None or not isinstance(
-            type_annotation, _LiteralGenericAlias
-        ):
+        if type_annotation is None or get_origin(type_annotation) is not Literal:
             _registry.register_base(cls)
         else:
             (type_name,) = type_annotation.__args__
             assert isinstance(type_name, str), type_name
-            assert type_name == name.removesuffix("Node")
             _registry.register(type_name, cls)
 
     @model_validator(mode="after")  # type: ignore
@@ -131,6 +177,89 @@ class Node(BaseModel, Generic[Input_contra, Output_co, Params_co]):
                 raise ValueError(f'Node type "{self.type}" is not registered')
             return cls.model_validate(self.model_dump())
         return self
+
+    # --------------------------------------------------------------------------
+    # NAMING
+
+    @property
+    def name(self) -> str:
+        """
+        A human-readable display name for the node, which may or may not be
+        unique.
+        By default, it is the node type joined with the node ID.
+        Override this method to provide a more meaningful name.
+        """
+        return f"{self.TYPE_INFO.name} {self.id}"
+
+    def with_namespace(self, namespace: str) -> Self:
+        """
+        Create a copy of this node with a namespaced ID.
+
+        Args:
+            namespace: The namespace to prefix the node ID with
+
+        Returns:
+            A new Node with ID '{namespace}/{self.id}'
+        """
+        return self.model_update(id=f"{namespace}/{self.id}")
+
+    # --------------------------------------------------------------------------
+    # VERSIONING
+
+    @property
+    def version_tuple(self) -> tuple[int, int, int]:
+        """
+        The major, minor, and patch version numbers of the node version.
+        If the node version is not provided, this will crash.
+        """
+        return parse_semver(self.version)
+
+    @model_validator(mode="after")
+    def validate_version(self):
+        """
+        Sets the node version to the current version of the node type.
+        Validates the node version against the TYPE_INFO version.
+        """
+        type_info = self.__class__.TYPE_INFO
+        if self.version == "":
+            with self.unfreeze():
+                self.version = type_info.version
+        elif type_info.version_tuple < self.version_tuple:
+            raise ValueError(
+                f"Node version {self.version} is newer than the latest version ({type_info.version}) supported by this workflow engine instance."
+            )
+        elif type_info.version_tuple > self.version_tuple:
+            warnings.warn(
+                f"Node version {self.version} is older than the latest version ({type_info.version}) supported by this workflow engine instance, and may need to be migrated."
+            )
+            # TODO: a migration system
+        return self
+
+    # --------------------------------------------------------------------------
+    # TYPING
+
+    @property
+    def input_type(self) -> Type[Input_contra]:  # type: ignore (contravariant return type)
+        # return Empty to spare users from having to specify the input type on
+        # nodes that don't have any input fields
+        return Empty  # type: ignore
+
+    @property
+    def output_type(self) -> Type[Output_co]:
+        # return Empty to spare users from having to specify the output type on
+        # nodes that don't have any output fields
+        return Empty  # type: ignore
+
+    @property
+    def input_fields(self) -> Mapping[str, tuple[ValueType, bool]]:  # type: ignore
+        return get_data_fields(self.input_type)
+
+    @property
+    def output_fields(self) -> Mapping[str, tuple[ValueType, bool]]:
+        return get_data_fields(self.output_type)
+
+    # --------------------------------------------------------------------------
+    # EXECUTION
 
     async def _cast_input(
         self,
@@ -175,14 +304,28 @@ class Node(BaseModel, Generic[Input_contra, Output_co, Params_co]):
                 f"Input {casted_input} for node {self.id} is invalid: {e}"
             )
 
+    # @abstractmethod
+    async def run(
+        self,
+        context: "Context",
+        input: Input_contra,
+    ) -> "Output_co | Workflow":
+        """
+        Computes the node's outputs based on its inputs.
+        Subclasses must implement this method, but it is not marked as abstract
+        because the base Node class needs to be instantiable for dispatching.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
     @final
     async def __call__(
         self,
         context: "Context",
         input: DataMapping,
-    ) -> Union[
-        DataMapping, "Workflow"
-    ]:  # Using Union instead of | due to Python 3.12 TypeAlias bug
+    ) -> "DataMapping | Workflow":
+        """
+        Executes the node.
+        """
         try:
             logger.info("Starting node %s", self.id)
             output = await context.on_node_start(node=self, input=input)
@@ -223,27 +366,6 @@ class Node(BaseModel, Generic[Input_contra, Output_co, Params_co]):
                 assert isinstance(e, Exception)
                 raise NodeException(self.id) from e
 
-    # @abstractmethod
-    # Using Union instead of | due to Python 3.12 TypeAlias bug
-    async def run(
-        self,
-        context: "Context",
-        input: Input_contra,
-    ) -> Union[Output_co, "Workflow"]:
-        raise NotImplementedError("Subclasses must implement this method")
-
-    def with_namespace(self, namespace: str) -> Self:
-        """
-        Create a copy of this node with a namespaced ID.
-
-        Args:
-            namespace: The namespace to prefix the node ID with
-
-        Returns:
-            A new Node with ID '{namespace}/{self.id}'
-        """
-        return self.model_copy(update={"id": f"{namespace}/{self.id}"})
-
 
 class NodeRegistry:
     def __init__(self):
@@ -276,6 +398,8 @@ _registry = NodeRegistry()
 
 
 __all__ = [
+    "Empty",
     "Node",
+    "NodeTypeInfo",
     "Params",
 ]

--- a/src/workflow_engine/core/value.py
+++ b/src/workflow_engine/core/value.py
@@ -19,7 +19,9 @@ from typing import (
     TypeVar,
 )
 
-from pydantic import ConfigDict, PrivateAttr, RootModel
+from pydantic import PrivateAttr
+
+from workflow_engine.utils.immutable import ImmutableRootModel
 
 if TYPE_CHECKING:
     from .context import Context
@@ -108,7 +110,7 @@ class GenericCaster(Protocol, Generic[SourceType, TargetType]):  # type: ignore
     ) -> Caster[SourceType, TargetType] | None: ...
 
 
-class Value(RootModel[T], Generic[T]):
+class Value(ImmutableRootModel[T], Generic[T]):
     """
     Wraps an arbitrary read-only value which can be passed as input to a node.
 
@@ -123,8 +125,6 @@ class Value(RootModel[T], Generic[T]):
     Once that cache is created, the casts are locked and can no longer be
     changed.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     # these properties force us to implement __eq__ and __hash__ to ignore them
     _casters: ClassVar[dict[str, GenericCaster]] = {}

--- a/src/workflow_engine/nodes/arithmetic.py
+++ b/src/workflow_engine/nodes/arithmetic.py
@@ -3,7 +3,7 @@
 Simple nodes for testing the workflow engine, with limited usefulness otherwise.
 """
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 from ..core import (
     Context,
@@ -12,6 +12,7 @@ from ..core import (
     FloatValue,
     IntegerValue,
     Node,
+    NodeTypeInfo,
     Params,
     SequenceValue,
 )
@@ -27,6 +28,13 @@ class SumOutput(Data):
 
 
 class AddNode(Node[AddNodeInput, SumOutput, Empty]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="Add",
+        display_name="Add",
+        description="Adds two numbers.",
+        version="0.4.0",
+    )
+
     type: Literal["Add"] = "Add"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
@@ -50,6 +58,13 @@ class SumNodeOutput(Data):
 
 
 class SumNode(Node[SumNodeInput, SumNodeOutput, Empty]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="Sum",
+        display_name="Sum",
+        description="Sums a sequence of numbers.",
+        version="0.4.0",
+    )
+
     type: Literal["Sum"] = "Sum"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
@@ -73,6 +88,13 @@ class FactorizationData(Data):
 
 
 class FactorizationNode(Node[IntegerData, FactorizationData, Params]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="Factorization",
+        display_name="Factorization",
+        description="Factorizes an integer into a sequence of its factors.",
+        version="0.4.0",
+    )
+
     type: Literal["Factorization"] = "Factorization"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property

--- a/src/workflow_engine/nodes/conditional.py
+++ b/src/workflow_engine/nodes/conditional.py
@@ -3,7 +3,7 @@
 Conditional nodes that run different workflows depending on a condition input.
 """
 
-from typing import Literal, Self, Type
+from typing import ClassVar, Literal, Self, Type
 
 from overrides import override
 from pydantic import ConfigDict
@@ -16,6 +16,7 @@ from ..core import (
     Data,
     Empty,
     Node,
+    NodeTypeInfo,
     Params,
     Workflow,
 )
@@ -32,7 +33,7 @@ class IfElseParams(Params):
 
 
 class ConditionalInput(Data):
-    model_config = ConfigDict(extra="allow")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 
     condition: BooleanValue
 
@@ -47,6 +48,13 @@ class IfNode(Node[ConditionalInput, Empty, IfParams]):
     """
 
     # TODO: allow conditional nodes with optional output
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="If",
+        display_name="If",
+        description="Executes the internal workflow if the boolean condition is true.",
+        version="0.4.0",
+    )
 
     type: Literal["If"] = "If"  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -90,6 +98,12 @@ class IfElseNode(Node[ConditionalInput, Data, IfElseParams]):
 
     # TODO: allow union types
 
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="IfElse",
+        display_name="IfElse",
+        description="Executes one of the two internal workflows based on the boolean condition.",
+        version="0.4.0",
+    )
     type: Literal["IfElse"] = "IfElse"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property

--- a/src/workflow_engine/nodes/constant.py
+++ b/src/workflow_engine/nodes/constant.py
@@ -1,5 +1,5 @@
 # workflow_engine/nodes/constant.py
-from typing import Literal, Type
+from typing import ClassVar, Literal, Type
 
 from ..core import (
     BooleanValue,
@@ -8,6 +8,7 @@ from ..core import (
     Empty,
     IntegerValue,
     Node,
+    NodeTypeInfo,
     Params,
     StringValue,
 )
@@ -18,6 +19,13 @@ class ConstantBoolean(Params):
 
 
 class ConstantBooleanNode(Node[Empty, ConstantBoolean, ConstantBoolean]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ConstantBoolean",
+        display_name="ConstantBoolean",
+        description="A node that outputs a constant boolean value.",
+        version="0.4.0",
+    )
+
     type: Literal["ConstantBoolean"] = "ConstantBoolean"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
@@ -37,6 +45,13 @@ class ConstantInteger(Params):
 
 
 class ConstantIntegerNode(Node[Empty, ConstantInteger, ConstantInteger]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ConstantInteger",
+        display_name="ConstantInteger",
+        description="A node that outputs a constant integer value.",
+        version="0.4.0",
+    )
+
     type: Literal["ConstantInteger"] = "ConstantInteger"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property
@@ -56,6 +71,13 @@ class ConstantString(Params):
 
 
 class ConstantStringNode(Node[Empty, ConstantString, ConstantString]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ConstantString",
+        display_name="ConstantString",
+        description="A node that outputs a constant string value.",
+        version="0.4.0",
+    )
+
     type: Literal["ConstantString"] = "ConstantString"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property

--- a/src/workflow_engine/nodes/data.py
+++ b/src/workflow_engine/nodes/data.py
@@ -5,7 +5,7 @@ Utility nodes to construct and deconstruct data objects.
 """
 
 from collections.abc import Sequence
-from typing import Generic, Literal, Self, Type, TypeVar
+from typing import ClassVar, Generic, Literal, Self, Type, TypeVar
 
 from overrides import override
 from pydantic import Field
@@ -19,6 +19,7 @@ from ..core import (
     Empty,
     IntegerValue,
     Node,
+    NodeTypeInfo,
     Params,
     SequenceValue,
     StringMapValue,
@@ -51,6 +52,13 @@ class GatherSequenceNode(Node[Data, SequenceData, SequenceParams]):
         >>> node.run(context, input={}).model_dump()
         {"sequence": [0, 1, 2]}
     """
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="GatherSequence",
+        display_name="GatherSequence",
+        description="Creates a new sequence object of a given length.",
+        version="0.4.0",
+    )
 
     type: Literal["GatherSequence"] = "GatherSequence"  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -108,6 +116,13 @@ class ExpandSequenceNode(Node[SequenceData, Data, SequenceParams]):
     """
     Extracts a sequence of elements to a data object.
     """
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ExpandSequence",
+        display_name="ExpandSequence",
+        description="Extracts a sequence of elements to a data object.",
+        version="0.4.0",
+    )
 
     type: Literal["ExpandSequence"] = "ExpandSequence"  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -186,6 +201,13 @@ class GatherMappingNode(Node[Data, MappingData, MappingParams]):
         {"mapping": {"a": 1, "b": 2, "c": 3}}
     """
 
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="GatherMapping",
+        display_name="GatherMapping",
+        description="Creates a new mapping object from the inputs to this node.",
+        version="0.4.0",
+    )
+
     type: Literal["GatherMapping"] = "GatherMapping"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the values in the mapping.
@@ -238,6 +260,13 @@ class ExpandMappingNode(Node[MappingData, Data, MappingParams]):
         >>> node.run(context, input={"mapping": {"a": 1, "b": 2, "c": 3}}).model_dump()
         {"a": 1, "b": 2, "c": 3}
     """
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ExpandMapping",
+        display_name="ExpandMapping",
+        description="Extracts values from a mapping object at specific keys.",
+        version="0.4.0",
+    )
 
     type: Literal["ExpandMapping"] = "ExpandMapping"  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -301,6 +330,13 @@ class GatherDataNode(Node[Data, NestedData, Empty]):
         {"data": {"a": 1, "b": 2, "c": 3}}
     """
 
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="GatherData",
+        display_name="GatherData",
+        description="A node that gathers a data object from the inputs to this node.",
+        version="0.4.0",
+    )
+
     type: Literal["GatherData"] = "GatherData"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     # The type of the element to extract.
@@ -341,6 +377,13 @@ class ExpandDataNode(Node[NestedData, Data, Empty]):
         >>> node.run(context, input={"data": {"a": 1, "b": 2, "c": 3}}).model_dump()
         {"a": 1, "b": 2, "c": 3}
     """
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ExpandData",
+        display_name="ExpandData",
+        description="A node that expands a nested data object into its individual fields.",
+        version="0.4.0",
+    )
 
     type: Literal["ExpandData"] = "ExpandData"  # pyright: ignore[reportIncompatibleVariableOverride]
 

--- a/src/workflow_engine/nodes/error.py
+++ b/src/workflow_engine/nodes/error.py
@@ -1,12 +1,13 @@
 # workflow_engine/nodes/error.py
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 from ..core import (
     Context,
     Data,
     Empty,
     Node,
+    NodeTypeInfo,
     Params,
     StringValue,
     UserException,
@@ -25,6 +26,13 @@ class ErrorNode(Node[ErrorInput, Empty, ErrorParams]):
     """
     A node that always raises an error.
     """
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="Error",
+        display_name="Error",
+        description="A node that always raises an error.",
+        version="0.4.0",
+    )
 
     type: Literal["Error"] = "Error"  # pyright: ignore[reportIncompatibleVariableOverride]
 

--- a/src/workflow_engine/nodes/iteration.py
+++ b/src/workflow_engine/nodes/iteration.py
@@ -3,7 +3,7 @@
 Nodes that iterate over a sequence of items.
 """
 
-from typing import Literal, Self, Type
+from typing import ClassVar, Literal, Self, Type
 
 from overrides import override
 
@@ -13,6 +13,7 @@ from ..core import (
     Edge,
     InputEdge,
     Node,
+    NodeTypeInfo,
     OutputEdge,
     Params,
     Workflow,
@@ -44,6 +45,13 @@ class ForEachNode(Node[SequenceData, SequenceData, ForEachParams]):
     The output of this node is a sequence of the same length as the input
     sequence, with each item being the output of the internal workflow.
     """
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="ForEach",
+        display_name="ForEach",
+        description="Executes the internal workflow for each item in the input sequence.",
+        version="0.4.0",
+    )
 
     type: Literal["ForEach"] = "ForEach"  # pyright: ignore[reportIncompatibleVariableOverride]
 

--- a/src/workflow_engine/nodes/text.py
+++ b/src/workflow_engine/nodes/text.py
@@ -1,12 +1,13 @@
 # workflow_engine/nodes/text.py
 import os
-from typing import Literal, Self
+from typing import ClassVar, Literal, Self
 
 from ..core import (
     Context,
     Data,
     File,
     Node,
+    NodeTypeInfo,
     Params,
     StringValue,
 )
@@ -27,6 +28,13 @@ class AppendToFileParams(Params):
 
 
 class AppendToFileNode(Node[AppendToFileInput, AppendToFileOutput, AppendToFileParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo(
+        name="AppendToFile",
+        display_name="AppendToFile",
+        description="Appends a string to the end of a file.",
+        version="0.4.0",
+    )
+
     type: Literal["AppendToFile"] = "AppendToFile"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     @property

--- a/src/workflow_engine/utils/immutable.py
+++ b/src/workflow_engine/utils/immutable.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import Any, Generic, Self, TypeVar
 from pydantic import BaseModel, ConfigDict, RootModel
 
@@ -10,46 +9,52 @@ _immutable_model_config = ConfigDict(
 )
 
 
-class ImmutableMixin:
+class _ImmutableMixin:
     """
     A base model that is immutable.
     """
 
     def __init_subclass__(cls, **kwargs):
         """
-        Make a deep copy of the model config so that each subclass can be
-        unfrozen independently.
+        Add the immutable model config to the rest of this class' model config.
         """
         cls.model_config = cls.model_config | _immutable_model_config
         super().__init_subclass__(**kwargs)
 
-    @contextmanager
-    def unfreeze(self):
-        """
-        Unfreeze the model for the duration of the context manager.
-        This affects all instances of the same subclass.
-        """
-        try:
-            self.model_config["frozen"] = False
-            yield self
-        finally:
-            self.model_config["frozen"] = True
 
+class ImmutableBaseModel(BaseModel, _ImmutableMixin):
     def model_update(self, **kwargs: Any) -> Self:
-        return self.model_copy(update=kwargs)  # type: ignore
+        """
+        Returns a new copy of the model with the given kwargs updated, and
+        validates the assignment.
+        Contrary to common belief, setting revalidate_instances="always" and
+        validate_assignment=True is not enough, because model_copy bypasses all
+        of that.
+        See https://github.com/pydantic/pydantic/issues/418
+        """
+        assert isinstance(self, BaseModel)
+        updated = self.model_copy(update=kwargs)  # type: ignore
+        self.__class__.model_validate(updated.__dict__)  # validate the updated model
+        return updated
 
-
-class ImmutableBaseModel(BaseModel, ImmutableMixin):
-    pass
+    def _model_mutate(self, **kwargs: Any):
+        """
+        Mutates the model in place despite its immutability.
+        This is obviously dangerous, so the method is protected.
+        To make it slightly safer, we validate the assignment via model_update.
+        """
+        updated = self.model_update(**kwargs)
+        self.__dict__.update(updated.__dict__)
 
 
 T = TypeVar("T")
 
 
-class ImmutableRootModel(RootModel[T], ImmutableMixin, Generic[T]):
+class ImmutableRootModel(RootModel[T], _ImmutableMixin, Generic[T]):
     pass
 
 
 __all__ = [
     "ImmutableBaseModel",
+    "ImmutableRootModel",
 ]

--- a/src/workflow_engine/utils/immutable.py
+++ b/src/workflow_engine/utils/immutable.py
@@ -1,0 +1,55 @@
+from contextlib import contextmanager
+from typing import Any, Generic, Self, TypeVar
+from pydantic import BaseModel, ConfigDict, RootModel
+
+
+_immutable_model_config = ConfigDict(
+    frozen=True,
+    revalidate_instances="always",
+    validate_assignment=True,
+)
+
+
+class ImmutableMixin:
+    """
+    A base model that is immutable.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        """
+        Make a deep copy of the model config so that each subclass can be
+        unfrozen independently.
+        """
+        cls.model_config = cls.model_config | _immutable_model_config
+        super().__init_subclass__(**kwargs)
+
+    @contextmanager
+    def unfreeze(self):
+        """
+        Unfreeze the model for the duration of the context manager.
+        This affects all instances of the same subclass.
+        """
+        try:
+            self.model_config["frozen"] = False
+            yield self
+        finally:
+            self.model_config["frozen"] = True
+
+    def model_update(self, **kwargs: Any) -> Self:
+        return self.model_copy(update=kwargs)  # type: ignore
+
+
+class ImmutableBaseModel(BaseModel, ImmutableMixin):
+    pass
+
+
+T = TypeVar("T")
+
+
+class ImmutableRootModel(RootModel[T], ImmutableMixin, Generic[T]):
+    pass
+
+
+__all__ = [
+    "ImmutableBaseModel",
+]

--- a/src/workflow_engine/utils/semver.py
+++ b/src/workflow_engine/utils/semver.py
@@ -1,8 +1,27 @@
-def parse_semver(version: str) -> tuple[int, int, int]:
-    major, minor, patch = version.split(".")
+# workflow_engine/utils/semver.py
+
+import re
+
+
+SEMANTIC_VERSION_PATTERN = r"^(\d+)\.(\d+)\.(\d+)$"
+_SEMANTIC_VERSION_REGEX = re.compile(SEMANTIC_VERSION_PATTERN)
+
+
+SEMANTIC_VERSION_OR_LATEST_PATTERN = r"^(\d+)\.(\d+)\.(\d+)$|^latest$"
+LATEST_SEMANTIC_VERSION = "latest"
+
+
+def parse_semantic_version(version: str) -> tuple[int, int, int]:
+    match = _SEMANTIC_VERSION_REGEX.match(version)
+    if match is None:
+        raise ValueError(f"Invalid semantic version: {version}")
+    major, minor, patch = match.groups()
     return int(major), int(minor), int(patch)
 
 
 __all__ = [
-    "parse_semver",
+    "parse_semantic_version",
+    "LATEST_SEMANTIC_VERSION",
+    "SEMANTIC_VERSION_PATTERN",
+    "SEMANTIC_VERSION_OR_LATEST_PATTERN",
 ]

--- a/src/workflow_engine/utils/semver.py
+++ b/src/workflow_engine/utils/semver.py
@@ -1,0 +1,8 @@
+def parse_semver(version: str) -> tuple[int, int, int]:
+    major, minor, patch = version.split(".")
+    return int(major), int(minor), int(patch)
+
+
+__all__ = [
+    "parse_semver",
+]

--- a/tests/test_addition.py
+++ b/tests/test_addition.py
@@ -1,12 +1,6 @@
 import pytest
 
-from workflow_engine import (
-    Edge,
-    InputEdge,
-    IntegerValue,
-    OutputEdge,
-    Workflow,
-)
+from workflow_engine import Edge, InputEdge, IntegerValue, OutputEdge, Workflow
 from workflow_engine.contexts import InMemoryContext
 from workflow_engine.execution import TopologicalExecutionAlgorithm
 from workflow_engine.nodes import AddNode, ConstantIntegerNode
@@ -64,7 +58,7 @@ def test_workflow_serialization(workflow: Workflow):
     """Test that the workflow can be serialized and deserialized correctly."""
     workflow_json = workflow.model_dump_json(indent=2)
     with open("examples/addition.json", "r") as f:
-        assert workflow_json == f.read()
+        assert workflow_json == f.read().strip()
 
     workflow_json = workflow.model_dump_json()
     deserialized_workflow = Workflow.model_validate_json(workflow_json)

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -4,9 +4,7 @@ from workflow_engine import File, InputEdge, OutputEdge, StringValue, Workflow
 from workflow_engine.contexts import InMemoryContext
 from workflow_engine.execution import TopologicalExecutionAlgorithm
 from workflow_engine.files import TextFileValue
-from workflow_engine.nodes import (
-    AppendToFileNode,
-)
+from workflow_engine.nodes import AppendToFileNode
 
 
 @pytest.fixture
@@ -35,7 +33,7 @@ def test_workflow_serialization(workflow: Workflow):
     """Test that the append workflow can be serialized and deserialized correctly."""
     workflow_json = workflow.model_dump_json(indent=2)
     with open("examples/append.json", "r") as f:
-        assert workflow_json == f.read()
+        assert workflow_json == f.read().strip()
 
     workflow_json = workflow.model_dump_json()
     deserialized_workflow = Workflow.model_validate_json(workflow_json)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -47,7 +47,7 @@ def test_workflow_serialization(workflow: Workflow):
     """Test that the error workflow can be serialized and deserialized correctly."""
     workflow_json = workflow.model_dump_json(indent=2)
     with open("examples/error.json", "r") as f:
-        assert workflow_json == f.read()
+        assert workflow_json == f.read().strip()
 
     deserialized_workflow = Workflow.model_validate_json(workflow_json)
     assert deserialized_workflow == workflow

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1,0 +1,119 @@
+from typing import ClassVar
+
+import pytest
+from pydantic import ConfigDict, ValidationError
+
+from workflow_engine.utils.immutable import (
+    ImmutableBaseModel,
+    ImmutableRootModel,
+)
+
+
+@pytest.fixture
+def TestImmutableModel():
+    """Test class that inherits from ImmutableBaseModel."""
+
+    class TestImmutableModel(ImmutableBaseModel):
+        name: str
+        age: int
+        active: bool = True
+
+    return TestImmutableModel
+
+
+@pytest.fixture
+def TestImmutableRootModel():
+    """Test class that inherits from ImmutableRootModel."""
+
+    class TestImmutableRootModel(ImmutableRootModel[str]):
+        pass
+
+    return TestImmutableRootModel
+
+
+@pytest.mark.unit
+def test_model_config_inheritance():
+    """Test that each subclass gets its own model config copy."""
+
+    class ModelA(ImmutableBaseModel):
+        model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+
+    class ModelB(ImmutableBaseModel):
+        model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    assert ModelA.model_config.get("extra") == "allow"
+    assert ModelB.model_config.get("extra") == "forbid"
+
+    assert ModelA.model_config.get("frozen") is True
+    assert ModelB.model_config.get("frozen") is True
+
+    assert ModelA.model_config.get("revalidate_instances") == "always"
+    assert ModelB.model_config.get("revalidate_instances") == "always"
+
+    assert ModelA.model_config.get("validate_assignment") is True
+    assert ModelB.model_config.get("validate_assignment") is True
+
+
+@pytest.mark.unit
+def test_immutable_base_model_immutability(TestImmutableModel):
+    """Test that ImmutableBaseModel instances are immutable."""
+    model = TestImmutableModel(name="John", age=30)
+
+    # Attempting to modify attributes should raise an error
+    with pytest.raises(ValidationError):
+        model.name = "Jane"
+    with pytest.raises(ValidationError):
+        model.age = 25
+
+    # Original values should remain unchanged
+    assert model.name == "John"
+    assert model.age == 30
+
+
+@pytest.mark.unit
+def test_immutable_root_model_immutability(TestImmutableRootModel):
+    """Test that ImmutableRootModel instances are immutable."""
+    model = TestImmutableRootModel(root="test string")
+
+    # Attempting to modify the root should raise an error
+    with pytest.raises(ValidationError):
+        model.root = "modified string"
+
+    # Original value should remain unchanged
+    assert model.root == "test string"
+
+
+@pytest.mark.unit
+def test_model_update_method(TestImmutableModel):
+    """Test that model_update method creates a new instance with updated values."""
+    original = TestImmutableModel(name="John", age=30, active=False)
+    updated = original.model_update(name="Jane", age=25)
+
+    # referentially different
+    assert updated is not original
+
+    # Original should remain unchanged
+    assert original.name == "John"
+    assert original.age == 30
+    assert original.active is False
+
+    # Updated should have new values
+    assert updated.name == "Jane"
+    assert updated.age == 25
+    assert updated.active is False
+
+
+@pytest.mark.unit
+def test_model_mutate_with_immutable_base_model(TestImmutableModel):
+    """Test that _model_mutate works with ImmutableBaseModel."""
+    model = TestImmutableModel(name="John", age=30, active=False)
+
+    # Use _model_mutate to update fields
+    model._model_mutate(name="Jane", age=25)
+    assert model.name == "Jane"
+    assert model.age == 25
+    assert model.active is False
+
+    # Model remains immutable
+    with pytest.raises(ValidationError):
+        model.name = "Modified"

--- a/tests/test_node_versioning.py
+++ b/tests/test_node_versioning.py
@@ -1,0 +1,149 @@
+# tests/test_node_versioning.py
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from workflow_engine import StringValue
+from workflow_engine.nodes import ConstantStringNode
+from workflow_engine.nodes.constant import ConstantString
+from workflow_engine.utils.semver import LATEST_SEMANTIC_VERSION
+
+
+class TestNodeVersioning:
+    """Test node versioning functionality using ConstantStringNode."""
+
+    @pytest.mark.unit
+    def test_default_version_when_none_provided(self):
+        """Test that when no version is provided, the node defaults to the current version."""
+        # Create a node without specifying version
+        node = ConstantStringNode(
+            id="test_node",
+            params=ConstantString(value=StringValue("test")),
+        )
+
+        # Should default to the current version from TYPE_INFO
+        assert node.version == "0.4.0"
+        assert node.version_tuple == (0, 4, 0)
+
+    @pytest.mark.unit
+    def test_serialization_includes_version(self):
+        """Test that serializing the node includes the version."""
+        # Create a node without specifying version
+        node = ConstantStringNode(
+            id="test_node",
+            params=ConstantString(value=StringValue("test")),
+        )
+
+        # Serialize the node
+        serialized = node.model_dump()
+
+        # Should include the version
+        assert "version" in serialized
+        assert serialized["version"] == "0.4.0"
+
+        # Should also work with JSON serialization
+        json_str = node.model_dump_json()
+        assert '"version":"0.4.0"' in json_str
+
+    @pytest.mark.unit
+    def test_older_version_triggers_warning(self):
+        """Test that providing an older version triggers a warning."""
+        # Create a node with an older version
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            node = ConstantStringNode(
+                id="test_node",
+                version="0.3.14",  # Older than current 0.4.0
+                params=ConstantString(value=StringValue("test")),
+            )
+
+            # Should have triggered a warning
+            assert len(w) == 1
+            warning = w[0]
+            assert issubclass(warning.category, UserWarning)
+
+            warning_message = str(warning.message)
+            assert (
+                "Node version 0.3.14 is older than the latest version (0.4.0) supported by this workflow engine instance, and may need to be migrated."
+                in warning_message
+            )
+
+            # Node should still be created successfully
+            assert node.version == "0.3.14"
+            assert node.version_tuple == (0, 3, 14)
+
+    @pytest.mark.unit
+    def test_newer_version_throws_error(self):
+        """Test that providing a newer version throws an error."""
+        with pytest.raises(ValidationError) as exc_info:
+            ConstantStringNode(
+                id="test_node",
+                version="0.5.0",  # Newer than current 0.4.0
+                params=ConstantString(value=StringValue("test")),
+            )
+
+        # Check that the error message is correct
+        error_message = str(exc_info.value)
+        assert (
+            "Node version 0.5.0 is newer than the latest version (0.4.0) supported by this workflow engine instance."
+            in error_message
+        )
+
+    @pytest.mark.unit
+    def test_same_version_no_warning(self):
+        """Test that providing the same version as current doesn't trigger warnings."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            node = ConstantStringNode(
+                id="test_node",
+                version="0.4.0",  # Same as current
+                params=ConstantString(value=StringValue("test")),
+            )
+
+            # Should not have triggered any warnings
+            assert len(w) == 0
+            assert node.version == "0.4.0"
+
+    @pytest.mark.unit
+    def test_latest_version_constant(self):
+        """Test that using LATEST_SEMANTIC_VERSION constant works correctly."""
+        node = ConstantStringNode(
+            id="test_node",
+            version=LATEST_SEMANTIC_VERSION,
+            params=ConstantString(value=StringValue("test")),
+        )
+
+        # Should default to the current version
+        assert node.version == "0.4.0"
+        assert node.version_tuple == (0, 4, 0)
+
+    @pytest.mark.unit
+    def test_version_validation_during_deserialization(self):
+        """Test that version validation works during deserialization."""
+        # Test with older version - should work but warn
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            node_data = {
+                "id": "test_node",
+                "type": "ConstantString",
+                "version": "0.3.0",
+                "params": {"value": "test"},
+            }
+
+            node = ConstantStringNode.model_validate(node_data)
+            assert len(w) == 1  # Should have warned
+            assert node.version == "0.3.0"
+
+        # Test with newer version - should fail
+        with pytest.raises(ValidationError):
+            node_data = {
+                "id": "test_node",
+                "type": "ConstantString",
+                "version": "0.5.0",
+                "params": {"value": "test"},
+            }
+            ConstantStringNode.model_validate(node_data)


### PR DESCRIPTION
This PR adds a few fields and behaviours to the `Node` class that users should appreciate:

- `TYPE_INFO`, a class variable containing a JSON-serializable dump of information about the node type -- e.g. for a frontend to display
  - We deliberately do not include the node parameters in `TYPE_INFO`, because this is a much larger change.
- A node-level `name` property that lets nodes customize their display names
- Semantic version numbers, making it possible to identify outdated nodes in systems like Aceteam where the node types evolve in potentially breaking ways.
  - With this PR, all of the existing built-in node types in Wengine will be initialized to `0.4.0`, which is the next release that will include this feature.

As a small code improvement, we also add a proper immutability mixin for all of the immutable classes throughout Wengine.

All pytests pass.