### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/src/workflow_engine/contexts/in_memory.py
+++ b/src/workflow_engine/contexts/in_memory.py
@@ -13,8 +13,7 @@ class InMemoryContext(Context):
     Pretends to be a file system, but actually stores files in memory.
     """
 
-    def __init__(self, *, run_id: str | None = None):
-        super().__init__(run_id=run_id)
+    def __init__(self):
         self.data: dict[str, bytes] = {}
 
     @override

--- a/src/workflow_engine/contexts/local.py
+++ b/src/workflow_engine/contexts/local.py
@@ -2,6 +2,7 @@
 import json
 import os
 from typing import TypeVar
+import uuid
 
 from overrides import override
 
@@ -31,9 +32,16 @@ class LocalContext(Context):
         run_id: str | None = None,
         base_dir: str = "./local",
     ):
-        super().__init__(run_id=run_id)
-        self.run_dir = os.path.join(base_dir, self.run_id)
-        os.makedirs(self.run_dir, exist_ok=True)
+        if run_id is None:
+            run_dir: str | None = None
+            while run_dir is None or os.path.exists(run_dir):
+                run_id = str(uuid.uuid4())
+                run_dir = os.path.join(base_dir, run_id)
+        else:
+            run_dir = os.path.join(base_dir, run_id)
+        os.makedirs(run_dir, exist_ok=True)
+        self.run_id = run_id
+        self.run_dir = run_dir
 
         self.files_dir = os.path.join(self.run_dir, "files")
         self.input_dir = os.path.join(self.run_dir, "input")

--- a/src/workflow_engine/core/context.py
+++ b/src/workflow_engine/core/context.py
@@ -1,5 +1,4 @@
 # workflow_engine/core/context.py
-import uuid
 from abc import ABC, abstractmethod
 from typing import TypeVar
 
@@ -18,15 +17,6 @@ class Context(ABC, EnforceOverrides):
     Represents the environment in which a workflow is executed.
     A context's life is limited to the execution of a single workflow.
     """
-
-    def __init__(
-        self,
-        *,
-        run_id: str | None = None,
-    ):
-        if run_id is None:
-            run_id = str(uuid.uuid4())
-        self.run_id = run_id
 
     @abstractmethod
     async def read(

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -25,6 +25,7 @@ from ..utils.immutable import ImmutableBaseModel
 from ..utils.semver import (
     LATEST_SEMANTIC_VERSION,
     SEMANTIC_VERSION_OR_LATEST_PATTERN,
+    SEMANTIC_VERSION_PATTERN,
     parse_semantic_version,
 )
 from .error import NodeException, UserException
@@ -91,7 +92,8 @@ class NodeTypeInfo(ImmutableBaseModel):
         description="A human-readable description of the node type."
     )
     version: str = Field(
-        description="A 3-part version number for the node, following semantic versioning rules (see https://semver.org/)."
+        description="A 3-part version number for the node, following semantic versioning rules (see https://semver.org/).",
+        pattern=SEMANTIC_VERSION_PATTERN,
     )
     parameter_schema: ValueSchema = Field(
         default_factory=lambda: Empty.to_value_schema(),
@@ -109,7 +111,7 @@ class NodeTypeInfo(ImmutableBaseModel):
         name: str,
         display_name: str,
         description: str | None = None,
-        version: str = LATEST_SEMANTIC_VERSION,
+        version: str,
         parameter_type: Type[Params],
     ) -> Self:
         return cls(

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -210,15 +210,19 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
     # --------------------------------------------------------------------------
     # NAMING
 
-    @property
-    def name(self) -> str:
+    async def display_name(self) -> str:
         """
-        A human-readable display name for the node, which may or may not be
+        A human-readable display name for the node, which is not necessarily
         unique.
-        By default, it is the node type joined with the node ID.
-        Override this method to provide a more meaningful name.
+        By default, it is the node type's display name, which is a poor default
+        at best.
+        You should override this method to provide a more meaningful name and
+        disambiguate nodes with the same type.
+
+        This method is async in case determining the node name requires some
+        asynchronous work.
         """
-        return f"{self.TYPE_INFO.name} {self.id}"
+        return self.TYPE_INFO.display_name
 
     def with_namespace(self, namespace: str) -> Self:
         """

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -210,7 +210,7 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
     # --------------------------------------------------------------------------
     # NAMING
 
-    async def display_name(self) -> str:
+    async def display_name(self, context: "Context") -> str:
         """
         A human-readable display name for the node, which is not necessarily
         unique.
@@ -220,7 +220,7 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
         disambiguate nodes with the same type.
 
         This method is async in case determining the node name requires some
-        asynchronous work.
+        asynchronous work, and can use the context.
         """
         return self.TYPE_INFO.display_name
 

--- a/src/workflow_engine/core/values/schema.py
+++ b/src/workflow_engine/core/values/schema.py
@@ -187,8 +187,9 @@ class FloatValueSchema(BaseValueSchema):
 
 
 class StringValueSchema(BaseValueSchema):
-    # unused JSON Schema fields include length and pattern
+    # unused JSON Schema fields include length
     type: Literal["string"]
+    enum: Sequence[str] | None = None
     pattern: str | None = None
 
     @override


### PR DESCRIPTION
- force users to provide a concrete numerical `TYPE_INFO.version`
- allow display name to be an async function dependent on context
- stop assuming the existence of workflow run IDs
- accept the `enum` property in string JSON schemas